### PR TITLE
let muted users know they are not permanently muted 

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -41,7 +41,7 @@ const errorstrings = new Map([
     ['invalidmsg', 'The message was invalid'],
     ['throttled', 'Throttled! You were trying to send messages too fast'],
     ['duplicate', 'The message is identical to the last one you sent'],
-    ['muted', 'You are muted (subscribing removes mutes). Check your profile for more information.'],
+    ['muted', 'You are muted (mutes are always temporary). Subscribing removes mutes: Check your profile for more information.'],
     ['submode', 'The channel is currently in subscriber only mode'],
     ['needbanreason', 'Providing a reason for the ban is mandatory'],
     ['banned', 'You have been banned (subscribing removes non-permanent bans). Check your profile for more information.'],


### PR DESCRIPTION
this happened to me and I ended up unsubscribing/resubscribing to remove the mute, because I was stupid and didn't know it was temporary. I later saw the startup hint that mutes are _always_ temporary and felt really stupid about it. 