### PR TITLE
Toggle message focus only on left click

### DIFF
--- a/assets/chat/js/focus.js
+++ b/assets/chat/js/focus.js
@@ -10,7 +10,11 @@ class ChatUserFocus {
         this.chat = chat;
         this.css = css;
         this.focused = [];
-        this.chat.output.on('mousedown', e => this.toggleElement(e.target));
+        this.chat.output.on('mousedown', e => {
+            if (e.originalEvent.button === 0) {
+                this.toggleElement(e.target)
+            }
+        });
     }
 
     toggleElement(target){


### PR DESCRIPTION
This commit changes the user focus behavior to only be triggered
when left clicking which allows e.g. middle clicking links without
dropping the message focus. Was tested on both desktop and mobile.