### PR TITLE
Fix `/ipban` command

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1245,10 +1245,13 @@ class Chat {
                 nick   : parts[0],
                 reason : parts.slice(2, parts.length).join(' ')
             };
-            if(command === 'IPBAN' || /^perm/i.test(parts[1]))
-                payload.ispermanent = (command === 'IPBAN' || /^perm/i.test(parts[1]));
+            if(/^perm/i.test(parts[1]))
+                payload.ispermanent = true;
             else
                 payload.duration = Chat.parseTimeInterval(parts[1]);
+
+            payload.banip = command === 'IPBAN';
+
             this.source.send('BAN', payload);
         }
     }


### PR DESCRIPTION
The `/ipban` command issues a permanent, non-IP ban instead of an IP ban. This PR modifies `cmdBAN()` to set `banip` in the ban payload to `true` when the command is used. The chat backend [uses this property](https://github.com/destinygg/chat/blob/5182d05ec93eef658226eea98b87f131644b389a/connection.go#L62) to determine if a ban should be an IP ban.