### PR TITLE
Update `Chat` to display ban appeal hint

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -991,7 +991,15 @@ class Chat {
         if(data === 'toomanyconnections' || data === 'banned') {
             this.source.retryOnDisconnect = false
         }
-        MessageBuilder.error(errorstrings.get(data) || data).into(this, this.getActiveWindow())
+
+        let messageText = errorstrings.get(data) || data
+
+        // Append ban appeal hint if a URL was provided.
+        if (data === 'banned' && this.config.banAppealUrl) {
+            messageText += ` Visit ${this.config.banAppealUrl} to appeal.`
+        }
+
+        MessageBuilder.error(messageText).into(this, this.getActiveWindow())
     }
 
     onSOCKETERROR(e){

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -184,7 +184,8 @@ class Chat {
             url: '',
             api: {base: ''},
             cdn: {base: ''},
-            cacheKey: ''
+            cacheKey: '',
+            banAppealUrl: null
         }, config)
         this.ui = null;
         this.css = null;

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "file-loader": "~3.0.1",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
-    "node-sass": "~4.11.0",
+    "node-sass": "~4.12.0",
     "postcss-loader": "^3.0.0",
     "sass-loader": "^7.3.1",
     "spritesmith": "~3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-chat-gui",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "description": "Destiny.gg chat client front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
This PR modifies `Chat` to accept a ban appeal URL as an argument. If supplied, a "ban appeal hint" will be displayed in chat to users who attempt to connect while banned.