### PR TITLE
Show users the time left until a mute expires

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -18,7 +18,7 @@ import ChatStore from './store'
 import Settings from './settings'
 import ChatWindow from './window'
 import ChatVote from './vote'
-import MutedTimer from './mutedtimer'
+import {isMuteActive, MutedTimer} from './mutedtimer'
 
 const regexslashcmd = /^\/([a-z0-9]+)[\s]?/i
 const regextime = /(\d+(?:\.\d*)?)([a-z]+)?/ig
@@ -953,8 +953,12 @@ class Chat {
         if(this.user.username.toLowerCase() === data.data.toLowerCase()) {
             MessageBuilder.command(`You have been muted by ${data.nick}.`, data.timestamp).into(this)
 
-            this.mutedtimer.setTimer(data.duration)
-            this.mutedtimer.startTimer()
+            // Every cached mute message calls `onMUTE()`. We perform this check
+            // to avoid setting the timer for mutes that have already expired.
+            if (isMuteActive(data)) {
+                this.mutedtimer.setTimer(data.duration)
+                this.mutedtimer.startTimer()
+            }
         } else {
             MessageBuilder.command(`${data.data} muted by ${data.nick}.`, data.timestamp).into(this)
         }

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -985,17 +985,17 @@ class Chat {
         }
     }
 
-    // NOTE this is an event that the chat server sends `ERR "$error"`
     // not to be confused with an error the chat.source may send onSOCKETERROR.
     onERR(data){
-        if(data === 'toomanyconnections' || data === 'banned') {
+        const desc = data.description
+        if(desc === 'toomanyconnections' || desc === 'banned') {
             this.source.retryOnDisconnect = false
         }
 
-        let messageText = errorstrings.get(data) || data
+        let messageText = errorstrings.get(desc) || desc
 
         // Append ban appeal hint if a URL was provided.
-        if (data === 'banned' && this.config.banAppealUrl) {
+        if (desc === 'banned' && this.config.banAppealUrl) {
             messageText += ` Visit ${this.config.banAppealUrl} to appeal.`
         }
 

--- a/assets/chat/js/mutedtimer.js
+++ b/assets/chat/js/mutedtimer.js
@@ -12,7 +12,7 @@ function isMuteActive(mute) {
     // Note that `timestamp` is in milliseconds, but `duration` is in seconds.
     let muteExpirationTime = moment(mute.timestamp)
     muteExpirationTime.add(mute.duration, 'seconds')
-    return muteExpirationTime.isSameOrAfter(now)
+    return muteExpirationTime.isAfter(now)
 }
 
 class MutedTimer {

--- a/assets/chat/js/mutedtimer.js
+++ b/assets/chat/js/mutedtimer.js
@@ -30,7 +30,7 @@ class MutedTimer {
         this.ticking = true
 
         // Save old input placeholder text to restore when the timer stops.
-        this.oldInputPlaceholder = this.chat.input.focus().attr('placeholder')
+        this.oldInputPlaceholder = this.chat.input.attr('placeholder')
 
         // Update placeholder text immediately to account for delay when using
         // `setInterval()`.
@@ -59,7 +59,7 @@ class MutedTimer {
         clearTimeout(this.timerTimeout)
 
         this.duration = null
-        this.chat.input.focus().attr('placeholder', this.oldInputPlaceholder)
+        this.chat.input.attr('placeholder', this.oldInputPlaceholder)
     }
 
     setTimer(secondsLeft = 0) {
@@ -74,7 +74,7 @@ class MutedTimer {
     }
 
     updatePlaceholderText() {
-        this.chat.input.focus().attr('placeholder', this.getPlaceholderText())
+        this.chat.input.attr('placeholder', this.getPlaceholderText())
     }
 
     getPlaceholderText() {

--- a/assets/chat/js/mutedtimer.js
+++ b/assets/chat/js/mutedtimer.js
@@ -1,5 +1,20 @@
 import moment from 'moment'
 
+function isMuteActive(mute) {
+    // If either field is `undefined`, we don't have enough information to
+    // determine if the mute is expired.
+    if (mute.timestamp == undefined || mute.duration == undefined) {
+        return null
+    }
+
+    const now = moment()
+
+    // Note that `timestamp` is in milliseconds, but `duration` is in seconds.
+    let muteExpirationTime = moment(mute.timestamp)
+    muteExpirationTime.add(mute.duration, 'seconds')
+    return muteExpirationTime.isSameOrAfter(now)
+}
+
 class MutedTimer {
     constructor(chat) {
         this.chat = chat
@@ -67,4 +82,7 @@ class MutedTimer {
     }
 }
 
-export default MutedTimer
+export {
+    isMuteActive,
+    MutedTimer
+}

--- a/assets/chat/js/mutedtimer.js
+++ b/assets/chat/js/mutedtimer.js
@@ -1,0 +1,70 @@
+import moment from 'moment'
+
+class MutedTimer {
+    constructor(chat) {
+        this.chat = chat
+        this.ticking = false
+        this.duration = null
+    }
+
+    startTimer() {
+        if (this.ticking || !this.duration) {
+            return
+        }
+
+        this.ticking = true
+
+        // Save old input placeholder text to restore when the timer stops.
+        this.oldInputPlaceholder = this.chat.input.focus().attr('placeholder')
+
+        // Update placeholder text immediately to account for delay when using
+        // `setInterval()`.
+        this.updatePlaceholderText()
+
+        // The timer ticks every second.
+        this.timerInterval = setInterval(() => this.tickTimer(), 1000)
+
+        // The timer stops when the mute expires.
+        this.timerTimeout = setTimeout(() => this.stopTimer(), this.duration.asMilliseconds())
+    }
+
+    tickTimer() {
+        this.duration = this.duration.subtract(1, 'seconds')
+        this.updatePlaceholderText()
+    }
+
+    stopTimer() {
+        if (!this.ticking) {
+            return
+        }
+
+        this.ticking = false
+
+        clearInterval(this.timerInterval)
+        clearTimeout(this.timerTimeout)
+
+        this.duration = null
+        this.chat.input.focus().attr('placeholder', this.oldInputPlaceholder)
+    }
+
+    setTimer(secondsLeft = 0) {
+        this.duration = moment.duration(secondsLeft, 'seconds')
+
+        // Reset the timeout function with the new mute duration if the timer is
+        // already ticking.
+        if (this.ticking) {
+            clearTimeout(self.timerTimeout)
+            this.timerTimeout = setTimeout(() => this.stopTimer(), this.duration.asMilliseconds())
+        }
+    }
+
+    updatePlaceholderText() {
+        this.chat.input.focus().attr('placeholder', this.getPlaceholderText())
+    }
+
+    getPlaceholderText() {
+        return `Sorry, ${this.chat.user.username}, you are muted. You can chat again in ${this.duration.humanize()}.`
+    }
+}
+
+export default MutedTimer

--- a/assets/chat/js/source.js
+++ b/assets/chat/js/source.js
@@ -107,7 +107,7 @@ class ChatSource extends EventEmitter {
         if(this.isConnected()){
             this.socket.send(`${eventname} ${payload}`)
         } else {
-            this.emit('ERR', 'notconnected')
+            this.emit('ERR', {description: 'notconnected'})
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-chat-gui",
-  "version": "2.3.4",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-chat-gui",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Destiny.gg chat client front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
Being muted in chat is a miserable experience. Not only because you can't post wonderful memes for all your chat friends to appreciate, but also because there's zero feedback as to when your mute expires. Without a clock, just a few minutes can feel like hours.

This PR shows the time left until a mute expires as placeholder text in the chat box. When the mute expires, the original placeholder text is restored. Additionally, chat error messages now display the mute time left, too.

![aboycalledsue muted](https://user-images.githubusercontent.com/20373896/90093217-e66de180-dcdf-11ea-8d5d-f65ced3757d8.png)

Note that the changes made to destinygg/chat in [this PR](https://github.com/destinygg/chat/pull/36) are necessary for this feature to work. After chat is deployed and website dependencies are updated, send a broadcast message with the text `reload` to force connected users to refresh the page and download the new JS.