### PR TITLE
Various fixes for mute duration timer

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1013,10 +1013,10 @@ class Chat {
                 }
                 break;
             case 'muted':
-                messageText = `You are temporarily muted! You can chat again in ${this.mutedtimer.duration.humanize()}. Subscribe to remove the mute immediately.`
-
                 this.mutedtimer.setTimer(data.muteTimeLeft)
                 this.mutedtimer.startTimer()
+
+                messageText = `You are temporarily muted! You can chat again in ${this.mutedtimer.duration.humanize()}. Subscribe to remove the mute immediately.`
                 break;
             default:
                 messageText = errorstrings.get(desc) || desc    

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1025,7 +1025,7 @@ class Chat {
                 this.mutedtimer.setTimer(data.muteTimeLeft)
                 this.mutedtimer.startTimer()
 
-                messageText = `You are temporarily muted! You can chat again in ${this.mutedtimer.duration.humanize()}. Subscribe to remove the mute immediately.`
+                messageText = `You are temporarily muted! You can chat again ${this.mutedtimer.getReadableDuration()}. Subscribe to remove the mute immediately.`
                 break;
             default:
                 messageText = errorstrings.get(desc) || desc    

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -298,10 +298,7 @@ class Chat {
             this.user = this.addUser(user)
             this.authenticated = true
         }
-        // TODO move this
-        if (this.authenticated) {
-            this.input.focus().attr('placeholder', `Write something ${this.user.username} ...`)
-        }
+        this.setDefaultPlaceholderText()
         return this
     }
 
@@ -481,7 +478,7 @@ class Chat {
         this.loadingscrn.fadeOut(250, () => this.loadingscrn.remove())
         this.mainwindow.updateAndPin()
 
-        this.input.focus().attr('placeholder', `Write something ...`)
+        this.setDefaultPlaceholderText()
         MessageBuilder.status(`Welcome to DGG chat`).into(this)
         return Promise.resolve(this)
     }
@@ -742,6 +739,13 @@ class Chat {
             if(win.locked()) win.unlock()
             this.redrawWindowIndicators()
         }
+
+        if (win.name === 'main' && this.mutedtimer.ticking) {
+            this.mutedtimer.updatePlaceholderText()
+        } else {
+            this.setDefaultPlaceholderText()
+        }
+
         return win
     }
 
@@ -844,6 +848,11 @@ class Chat {
         if(window.getSelection().isCollapsed && !this.input.is(':focus')) {
             this['debounceFocus'](this);
         }
+    }
+
+    setDefaultPlaceholderText() {
+        const placeholderText = this.authenticated ? `Write something ${this.user.username} ...` : `Write something ...`
+        this.input.attr('placeholder', placeholderText)
     }
 
     /**

--- a/assets/chat/js/mutedtimer.js
+++ b/assets/chat/js/mutedtimer.js
@@ -79,7 +79,11 @@ class MutedTimer {
     }
 
     getPlaceholderText() {
-        return `Sorry, ${this.chat.user.username}, you are muted. You can chat again in ${this.duration.humanize()}.`
+        return `Sorry, ${this.chat.user.username}, you are muted. You can chat again ${this.getReadableDuration()}.`
+    }
+
+    getReadableDuration() {
+        return this.duration.humanize(true, {s: 60, ss: 2})
     }
 }
 

--- a/assets/chat/js/mutedtimer.js
+++ b/assets/chat/js/mutedtimer.js
@@ -29,9 +29,6 @@ class MutedTimer {
 
         this.ticking = true
 
-        // Save old input placeholder text to restore when the timer stops.
-        this.oldInputPlaceholder = this.chat.input.attr('placeholder')
-
         // Update placeholder text immediately to account for delay when using
         // `setInterval()`.
         this.updatePlaceholderText()
@@ -59,7 +56,7 @@ class MutedTimer {
         clearTimeout(this.timerTimeout)
 
         this.duration = null
-        this.chat.input.attr('placeholder', this.oldInputPlaceholder)
+        this.chat.setDefaultPlaceholderText()
     }
 
     setTimer(secondsLeft = 0) {
@@ -74,7 +71,11 @@ class MutedTimer {
     }
 
     updatePlaceholderText() {
-        this.chat.input.attr('placeholder', this.getPlaceholderText())
+        // Only update the placeholder text when the main chat window is active.
+        // A muted user can still send messages in direct message windows.
+        if (this.chat.getActiveWindow().name === 'main') {
+            this.chat.input.attr('placeholder', this.getPlaceholderText())
+        }
     }
 
     getPlaceholderText() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-chat-gui",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6059,9 +6059,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.25.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
+      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "jquery": "^3.4.1",
-    "moment": "~2.24.0",
+    "moment": "~2.25.0",
     "nanoscroller": "~0.8.7",
     "normalize.css": "~8.0.1",
     "throttle-debounce": "~2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-chat-gui",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Destiny.gg chat client front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
* Fixes an unfortunate bug related to setting the muted timer that broke stuff a lot. 😫
* Displays the standard placeholder text in DM conversation windows.
* If there's less than one minute left until a mute expires, shows exactly how many seconds to go instead of just `a few seconds`.