### PR TITLE
Allow disabling formatters when creating a `ChatMessage`

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1017,7 +1017,7 @@ class Chat {
 
         switch (desc) {
             case 'banned':
-                let messageText = 'You have been banned (<a target="_blank" class="externallink" href="/subscribe" rel="nofollow">subscribing</a> removes non-permanent bans). Check your profile for more information.'
+                let messageText = 'You have been banned! Check your profile for more information. <a target="_blank" class="externallink" href="/subscribe" rel="nofollow">Subscribing</a> or <a target="_blank" class="externallink" href="/donate" rel="nofollow">donating</a> removes non-permanent bans.'
 
                 // Append ban appeal hint if a URL was provided.
                 if (this.config.banAppealUrl) {

--- a/assets/chat/js/messages.js
+++ b/assets/chat/js/messages.js
@@ -23,25 +23,6 @@ formatters.set('mentioned', new MentionedUserFormatter())
 formatters.set('green', new GreenTextFormatter())
 formatters.set('embed', new EmbedUrlFormatter())
 
-function buildMessageTxt(chat, message){
-    // TODO we strip off the `/me ` of every message -- must be a better way to do this
-    let msg = message.message.substring(0, 4).toLowerCase() === '/me ' ? message.message.substring(4) : message.message
-    formatters.forEach(f => msg = f.format(chat, msg, message))
-    return `<span class="text">${msg}</span>`
-}
-function buildFeatures(user, chat){
-    const features = (user.features || [])
-        .filter(e => chat.flairsMap.has(e))
-        .map(e => chat.flairsMap.get(e))
-        .reduce((str, e) => str + `<i class="flair ${e['name']}" title="${e['label']}"></i> `, '');
-    return features !== '' ? `<span class="features">${features}</span>` : '';
-}
-function buildTime(message){
-    const datetime = message.timestamp.format(DATE_FORMATS.FULL);
-    const label = message.timestamp.format(DATE_FORMATS.TIME);
-    return `<time class="time" title="${datetime}">${label}</time>`;
-}
-
 class MessageBuilder {
 
     static element(message, classes=[]){
@@ -139,8 +120,22 @@ class ChatMessage extends ChatUIMessage {
         const classes = [], attr = {};
         if(this.continued)
             classes.push('msg-continue');
-        return this.wrap(`${buildTime(this)} ${buildMessageTxt(chat, this)}`, classes, attr);
+        return this.wrap(`${this.buildTime()} ${this.buildMessageTxt(chat)}`, classes, attr);
     }
+
+    buildMessageTxt(chat){
+        // TODO we strip off the `/me ` of every message -- must be a better way to do this
+        let msg = this.message.substring(0, 4).toLowerCase() === '/me ' ? this.message.substring(4) : this.message
+        formatters.forEach(f => msg = f.format(chat, msg, this))
+        return `<span class="text">${msg}</span>`
+    }
+
+    buildTime(){
+        const datetime = this.timestamp.format(DATE_FORMATS.FULL);
+        const label = this.timestamp.format(DATE_FORMATS.TIME);
+        return `<time class="time" title="${datetime}">${label}</time>`;
+    }
+
 }
 
 class ChatUserMessage extends ChatMessage {
@@ -190,8 +185,16 @@ class ChatUserMessage extends ChatMessage {
         else if(this.slashme || this.continued)
             ctrl = '';
 
-        const user = buildFeatures(this.user, chat) + ` <a title="${this.title}" class="user ${this.user.features.join(' ')}">${this.user.username}</a>`;
-        return this.wrap(buildTime(this) + ` ${user}<span class="ctrl">${ctrl}</span> ` + buildMessageTxt(chat, this), classes, attr);
+        const user = this.buildFeatures(this.user, chat) + ` <a title="${this.title}" class="user ${this.user.features.join(' ')}">${this.user.username}</a>`;
+        return this.wrap(this.buildTime() + ` ${user}<span class="ctrl">${ctrl}</span> ` + this.buildMessageTxt(chat), classes, attr);
+    }
+
+    buildFeatures(user, chat){
+        const features = (user.features || [])
+            .filter(e => chat.flairsMap.has(e))
+            .map(e => chat.flairsMap.get(e))
+            .reduce((str, e) => str + `<i class="flair ${e['name']}" title="${e['label']}"></i> `, '');
+        return features !== '' ? `<span class="features">${features}</span>` : '';
     }
 
 }
@@ -232,7 +235,7 @@ class ChatEmoteMessage extends ChatMessage {
         this._combo_x       = $(`<i class="x">X</i>`)
         this._combo_hits    = $(`<i class="hit">Hits</i>`)
         this._combo_txt     = $(`<i class="combo">C-C-C-COMBO</i>`)
-        return this.wrap(buildTime(this))
+        return this.wrap(this.buildTime())
     }
 
     afterRender(chat=null){

--- a/assets/chat/js/messages.js
+++ b/assets/chat/js/messages.js
@@ -259,5 +259,6 @@ class ChatEmoteMessage extends ChatMessage {
 
 export {
     MessageBuilder,
-    MessageTypes
+    MessageTypes,
+    ChatMessage
 };

--- a/assets/chat/js/messages.js
+++ b/assets/chat/js/messages.js
@@ -108,12 +108,13 @@ class ChatUIMessage {
 
 class ChatMessage extends ChatUIMessage {
 
-    constructor(message, timestamp=null, type=MessageTypes.CHAT){
+    constructor(message, timestamp=null, type=MessageTypes.CHAT, unformatted=false){
         super(message);
         this.user = null;
         this.type = type;
         this.continued = false;
         this.timestamp = timestamp ? moment.utc(timestamp).local() : moment();
+        this.unformatted = unformatted;
     }
 
     html(chat=null){
@@ -126,7 +127,7 @@ class ChatMessage extends ChatUIMessage {
     buildMessageTxt(chat){
         // TODO we strip off the `/me ` of every message -- must be a better way to do this
         let msg = this.message.substring(0, 4).toLowerCase() === '/me ' ? this.message.substring(4) : this.message
-        formatters.forEach(f => msg = f.format(chat, msg, this))
+        if (!this.unformatted) formatters.forEach(f => msg = f.format(chat, msg, this))
         return `<span class="text">${msg}</span>`
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-chat-gui",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-chat-gui",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "description": "Destiny.gg chat client front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
This PR modifies `ChatMessage` to allow for the creation of messages that contain HTML. The class' constructor now accepts an additional parameter, `unformatted`, that dictates whether or not it should run its formatters on the message text. One of the formatters [sanitizes HTML](https://github.com/destinygg/chat-gui/blob/c9381fe51a1b12558f8b44d58e5b4ffd30dbbb45/assets/chat/js/formatters.js#L9-L16) and another [linkifies text](https://github.com/destinygg/chat-gui/blob/c9381fe51a1b12558f8b44d58e5b4ffd30dbbb45/assets/chat/js/formatters.js#L54-L129). With these two formatters disabled, we can easily craft `ChatMessage`s with cleaner-looking links.

Before
![linkify text before](https://user-images.githubusercontent.com/20373896/93686122-058f2a00-fa69-11ea-866c-f96471aa9a39.png)

After
![linkify text after](https://user-images.githubusercontent.com/20373896/93686126-09bb4780-fa69-11ea-9d5b-ff908000c29f.png)