### PR TITLE
Some tweaks to improve embed handling

### DIFF
--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -146,7 +146,14 @@ class EmbedUrlFormatter {
     format(chat, str/*, message=null*/) {
         // Open embed links in a new tab when in embedded/popout chat.
         const target = this.currentPath === this.bigscreenPath ? '_top' : '_blank'
-        return str.replace(this.bigscreenregex, '$1<a class="externallink bookmarklink" href="' + this.url + '$2" target="' + target + '">$2</a>')
+        let extraclass = '';
+
+        if(/\b(?:NSFL)\b/i.test(str))
+            extraclass = 'nsfl-link';
+        else if(/\b(?:NSFW|SPOILER)\b/i.test(str))
+            extraclass = 'nsfw-link';
+
+        return str.replace(this.bigscreenregex, `$1<a class="externallink bookmarklink ${extraclass}" href="${this.url}$2" target="${target}">$2</a>`)
     }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-chat-gui",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Destiny.gg chat client front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
Hello there!

I noticed that in dgg there's no easy way to:
1. Embed something without posting it in chat (you have to first modify the link, then paste it into the address bar)
2. Post an embed in chat that you don't have embedded currently (once again, you need to modify the link first)
3. Post an embed in chat that you DO have embedded currently (you have to copy it from the address bar)

So I thought I would implement a couple of commands that help with that!

## 1. /embed or /e

https://user-images.githubusercontent.com/41237021/130905983-d0da4d9e-ffa5-4a7f-85cd-b9956dc03d3c.mp4

Simple enough: ```/embed <link>``` embeds something in bigscreen

## 2. /postembed or /pe

https://user-images.githubusercontent.com/41237021/130906124-0ac0a1b5-633b-44b7-b09d-b71325c16fea.mp4

Posts an embed in chat that you either have embedded right now, or the one you include with the command. You can also include a message with the embed.
```/postembed```
```/postembed <link>```
```/postembed <link> <msg>```

## 3. nsfw/nsfl highlighting for embeds

I probably should've done this in a separate pull request FeelsDankMan, but yeah, there was not nsfw/nsfl highlighting for embeds and it was easy enough to implement!

You can see it in the /postembed video :)

❤️ 