### PR TITLE
Fix twitch subs' ability to spam spaces

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -572,7 +572,7 @@ class Chat {
         const emoticons = emotes.filter(v => !v['twitch']).map(v => v['prefix']).join('|'),
             twitchemotes = emotes.filter(v => v['twitch']).map(v => v['prefix']).join('|')
         this.emoteRegexNormal = new RegExp(`(^|\\s)(${emoticons})(?=$|\\s)`, 'gm')
-        this.emoteRegexTwitch = new RegExp(`(^|\\s)(${emoticons}|${twitchemotes})(?=$|\\s)`, 'gm')
+        this.emoteRegexTwitch = (twitchemotes.length > 0) ? new RegExp(`(^|\\s)(${emoticons}|${twitchemotes})(?=$|\\s)`, 'gm') : this.emoteRegexNormal
         this.emotePrefixes = new Set([...emotes.map(v => v['prefix'])])
         this.emotePrefixes.forEach(e => this.autocomplete.add(e, true))
         return this;


### PR DESCRIPTION
Hi there again!

Some time ago I (and some chatters) noticed a bug that allowed you to put as many spaces in a message as you wanted, which could mess up tagging people and/or emotes. Not cool! However, only a limited amount of people experienced it and nobody could quite put a finger on what's causing it.

![how the bug looks like](https://user-images.githubusercontent.com/41237021/133767586-d33e6186-5525-4968-84db-f3e8505e1f4d.png)

I thought it was some autocomplete issue messing up messages, turns out it's way more obvious: it's emote regex stuff.

When Steve got unpartnered, all Twitch sub only emotes got turned into normal ones and Twitch subs got removed; recently though, Destiny got affiliate and Twitch subs came back. This caused a regex meme to pop up: for Twitch subs the regex is different, and, with no Twitch sub only emotes, it starts counting spaces as blank emotes.

Here are some screenshots from regex101 explaining the bug:

1. Current normal emote regex (notice no OR symbol at the end)
![no OR](https://user-images.githubusercontent.com/41237021/133767917-1411a5ba-2b3c-400f-9f2b-aad605a5757d.png)
2. Current Twitch sub emote regex (this time the OR symbol appears and messes shit up)
![OR appears](https://user-images.githubusercontent.com/41237021/133768142-c2102fa8-781e-4996-aabc-d04d36f9e1a4.png)

Here is a lidl one line fix, unfortunately, I couldn't test it on my setup (for whatever reason I can't add emotes locally FeelsDankMan), so you're gonna have to double-check everything NODDERS It seemed to work fine in the browser console tho FeelsDankMan