### PR TITLE
Fix whispers not being read in some cases and add a command to open a convo tab

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -457,6 +457,7 @@ class Chat {
         this.windowselect.on('click', '.tab', e => {
             ChatMenu.closeMenus(this)
             this.windowToFront($(e.currentTarget).data('name').toLowerCase())
+            this.menus.get('whisper-users').redraw()
             this.input.focus()
             return false
         })
@@ -1813,6 +1814,11 @@ class Chat {
                         }
                     })
                     .catch(() => MessageBuilder.error(`Failed to load messages :(`).into(this, win))
+            } else {
+                if (conv.unread > 0) {
+                    fetch(`${this.config.api.base}/api/messages/usr/${encodeURIComponent(normalized)}/inbox`, {credentials: 'include'})
+                        .catch(() => MessageBuilder.error(`Failed to mark messages as read :(`).into(this, win))
+                }
             }
             conv.unread = 0
             conv.open = true

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -151,6 +151,10 @@ const commandsinfo = new Map([
         desc: 'Posts embedded content in chat or generates and posts an embeddable link',
         alias: ['pe']
     }],
+    ['open', {
+        desc: 'Opens a conversation',
+        alias: ['o']
+    }],
     ['exit', {
         desc: 'Exit the conversation you are in.'
     }],
@@ -288,6 +292,8 @@ class Chat {
         this.control.on('POSTEMBED', data => this.cmdPOSTEMBED(data));
         this.control.on('PE', data => this.cmdPOSTEMBED(data));
         this.control.on('BANINFO', data => this.cmdBANINFO(data));
+        this.control.on('OPEN', data => this.cmdOPEN(data));
+        this.control.on('O', data => this.cmdOPEN(data));
         this.control.on('EXIT', data => this.cmdEXIT(data));
         this.control.on('MESSAGE', data => this.cmdWHISPER(data));
         this.control.on('MSG', data => this.cmdWHISPER(data));
@@ -1679,6 +1685,28 @@ class Chat {
                 MessageBuilder.info(`End of ban information`).into(this);
             })
             .catch(() => MessageBuilder.error('Error loading ban info. Check your profile.').into(this));
+    }
+
+    cmdOPEN(parts){
+        if (!parts[0]) {
+            MessageBuilder.error('No username specified - /open <username> OR /o <username>').into(this);
+        } else if (parts.length > 1) {
+            MessageBuilder.error('Too many arguments provided - /open <username> OR /o <username>').into(this);
+        } else {
+            if (parts[0] !== this.user.username) {
+                const normalized = parts[0].toLowerCase()
+                const win = this.getWindow(normalized)
+                if (win !== (null || undefined)) {
+                    this.windowToFront(normalized)
+                } else {
+                    if (!this.whispers.has(normalized))
+                        this.whispers.set(normalized, {nick: normalized, unread: 0, open: false})
+                    this.openConversation(normalized)
+                }
+            } else {
+                MessageBuilder.error("Can't open a convo with yourself - /open <username> OR /o <username>").into(this);
+            }
+        }
     }
 
     cmdEXIT(){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-chat-gui",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "Destiny.gg chat client front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
Hey again!

## Whispers bugfix

I use a lot of whispers in dgg and it always pissed me off that they don't get read sometimes. After some debugging I figured out that if you switch to an already open tab, the messages don't get marked as read. Easy enough fix! (took some time to find out the right place to put the code in tho PepoG)

### Current behavior

https://user-images.githubusercontent.com/41237021/136707389-72df7d86-7282-45cf-a5f3-efd8526dc9ed.mp4

### Fixed behavior

https://user-images.githubusercontent.com/41237021/136707398-f488574f-4380-42ad-a57a-a86b9f1dd5c2.mp4

## /open OR /o

There's currently no way to open a convo directly from chat, this command makes it possible PepoComfy 

https://user-images.githubusercontent.com/41237021/136707511-217e1fe0-1ccf-4337-9591-fd17d4858c3a.mp4

One issue with it is that it's possible to open a convo with a non-existing user, but it tells you that it can't load the messages, so I don't think it's a big problem PepoG

![non-existing_user](https://user-images.githubusercontent.com/41237021/136707542-8f8213bc-7882-4d98-84fe-cbd56a1d2eab.png)

