### PR TITLE
Assorted bugfixes: autocomplete helper css and spoiler highlighting

### DIFF
--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -80,6 +80,9 @@ function timeoutHelpers(ac){
 function updateHelpers(ac){
     ac.chat.ui.toggleClass('chat-autocomplete-in', ac.results.length > 0)
     ac.ui.toggleClass('active', ac.results.length > 0)
+    if (ac.results.length === 0) {
+        ac.container.css('left', 0)
+    }
 }
 function selectHelper(ac) {
     // Positioning

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -95,7 +95,7 @@ function selectHelper(ac) {
         $(list[Math.max(0, ac.selected - 2)]).each((i, e) => {
             const left = $(e).position().left + offset
             if(left < 0)
-                ac.container.css('left', $(e).position().left)
+                ac.container.css('left', -$(e).position().left)
         })
         list.forEach((e, i) => $(e).toggleClass('active', i === ac.selected))
     }

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -80,9 +80,6 @@ function timeoutHelpers(ac){
 function updateHelpers(ac){
     ac.chat.ui.toggleClass('chat-autocomplete-in', ac.results.length > 0)
     ac.ui.toggleClass('active', ac.results.length > 0)
-    if (ac.results.length === 0) {
-        ac.container.css('left', 0)
-    }
 }
 function selectHelper(ac) {
     // Positioning

--- a/assets/chat/js/formatters.js
+++ b/assets/chat/js/formatters.js
@@ -109,7 +109,7 @@ class UrlFormatter {
 
         if(/\b(?:NSFL)\b/i.test(str))
             extraclass = 'nsfl-link';
-        else if(/\b(?:NSFW|SPOILER)\b/i.test(str))
+        else if(/\b(?:NSFW|SPOILERS?)\b/i.test(str))
             extraclass = 'nsfw-link';
 
         return str.replace(self.linkregex, function(url, scheme) {
@@ -150,7 +150,7 @@ class EmbedUrlFormatter {
 
         if(/\b(?:NSFL)\b/i.test(str))
             extraclass = 'nsfl-link';
-        else if(/\b(?:NSFW|SPOILER)\b/i.test(str))
+        else if(/\b(?:NSFW|SPOILERS?)\b/i.test(str))
             extraclass = 'nsfw-link';
 
         return str.replace(this.bigscreenregex, `$1<a class="externallink bookmarklink ${extraclass}" href="${this.url}$2" target="${target}">$2</a>`)


### PR DESCRIPTION
## Spoiler highlighting

"spoilers" (with an 's' at the end) used to not highlight links red... Now it does! Very nice! (mentioned in #26)

![regex101](https://user-images.githubusercontent.com/41237021/137076420-735dcdba-a211-45e7-bee1-25c81c19c788.png)

## Autocomplete helper shenanigans

This is a more of a preliminary bugfix for a bigger autocomplete helper issue: sometimes it goes off the rails and slides off of the screen (if the chat area is small enough, so, like, on a phone). While what I added in (resetting the css of the helper on it's close/timeout) doesn't fix that problem, at least it makes it bearable to chat on mobile without having to refresh once it disappears.

![too far to the right!](https://user-images.githubusercontent.com/41237021/137076564-f361e508-588c-43ba-a2c2-74f28c2c3d19.png)
