### PR TITLE
Fix mobile keyboard popping up every press

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1164,10 +1164,15 @@ class Chat {
   }
 
   focusIfNothingSelected() {
+    // If this is a mobile screen, return to avoid focusing input and bringing up the virtual keyboard
+    if (window.screen.width <= 768) {
+      return;
+    }
+
     if (this.debounceFocus === undefined) {
       this.debounceFocus = debounce(10, false, (c) => c.input.focus());
     }
-    if(window.screen.width > 768 && window.getSelection().isCollapsed && !this.input.is(':focus')) {
+    if (window.getSelection().isCollapsed && !this.input.is(':focus')) {
       this.debounceFocus(this);
     }
   }

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1167,7 +1167,7 @@ class Chat {
     if (this.debounceFocus === undefined) {
       this.debounceFocus = debounce(10, false, (c) => c.input.focus());
     }
-    if (window.getSelection().isCollapsed && !this.input.is(':focus')) {
+    if(window.screen.width > 768 && window.getSelection().isCollapsed && !this.input.is(':focus')) {
       this.debounceFocus(this);
     }
   }


### PR DESCRIPTION
The dgg chat on mobile is very annoying to use because every time you press anywhere on the screen it re-focuses the chat input, causing the virtual keyboard to pop up.

See: 

https://user-images.githubusercontent.com/6654122/151734639-38e654dd-4b36-4096-9f1e-2b83d8dc063e.mp4

Obviously you can't see me tap the screen, but I'm doing it every time the mobile keyboard closes and re-opens. It happens if I tap anywhere in the chat, or focus someone's username.

I updated the `focusIfNothingSelected` function to only focus the chat input if the screen-size is greater than 768px.

See:


https://user-images.githubusercontent.com/6654122/151734877-50e0b9ce-b4c5-491d-b835-b913b25912ea.mp4

Tapping in the chat or on a username doesn't focus the input and doesn't bring up the virtual keyboard. At the end I do bring up the keyboard, and show that tapping in the chat outside of the input element closes the keyboard, as expected.