### PR TITLE
Baseline Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  -
+    package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  -
+    package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Noticed some dependencies in the `package.json` were out of date. Dependabot can easily assist with this by sending automated PRs; I set it to a weekly interval to make things easier to maintain (daily can be quite annoying sometimes)

Figured this was better than sending the PRs for updating them myself.