### PR TITLE
Show account creation date in user info menu

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -892,11 +892,19 @@ class Chat {
     if (!user) {
       user = new ChatUser(data);
       this.users.set(normalized, user);
-    } else if (
-      Object.hasOwn(data, 'features') &&
-      !Chat.isArraysEqual(data.features, user.features)
-    ) {
-      user.features = data.features;
+    } else {
+      if (
+        Object.hasOwn(data, 'features') &&
+        !Chat.isArraysEqual(data.features, user.features)
+      ) {
+        user.features = data.features;
+      }
+      if (
+        Object.hasOwn(data, 'createdDate') &&
+        data.createdDate !== user.createdDate
+      ) {
+        user.createdDate = data.createdDate;
+      }
     }
     return user;
   }

--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import moment from 'moment';
 import ChatMenu from './ChatMenu';
 import { MessageBuilder } from '../messages';
 import ChatUser from '../user';
@@ -12,11 +13,13 @@ export default class ChatUserInfoMenu extends ChatMenu {
 
     this.header = this.ui.find('.toolbar span');
 
+    this.createdDateSubheader = this.ui.find('.user-info h5.date-subheader')[0];
+
     this.flairList = this.ui.find('.user-info .flairs');
-    [this.flairSubheader] = this.ui.find('.user-info h5');
+    this.flairSubheader = this.ui.find('.user-info h5.flairs-subheader')[0];
 
     this.messagesContainer = this.ui.find('.content');
-    [, this.messagesSubheader] = this.ui.find('.user-info h5');
+    this.messagesSubheader = this.ui.find('.user-info h5.stalk-subheader')[0];
 
     this.muteUserBtn = this.ui.find('#mute-user-btn');
     this.banUserBtn = this.ui.find('#ban-user-btn');
@@ -213,6 +216,17 @@ export default class ChatUserInfoMenu extends ChatMenu {
     const nick = message.data('username');
     const usernameFeatures = message.find('.user')[0].attributes.class.value;
 
+    const formattedDate = this.buildCreatedDate(nick);
+    if (formattedDate === '') {
+      this.createdDateSubheader.style.display = 'none';
+      this.createdDateSubheader.replaceChildren(
+        'Unable to display account creation date'
+      );
+    } else {
+      this.createdDateSubheader.style.display = '';
+      this.createdDateSubheader.replaceChildren('Joined on ', formattedDate);
+    }
+
     const featuresList = this.buildFeatures(nick, usernameFeatures);
     if (featuresList === '') {
       this.flairList.toggleClass('hidden', true);
@@ -242,6 +256,20 @@ export default class ChatUserInfoMenu extends ChatMenu {
     });
 
     super.redraw();
+  }
+
+  buildCreatedDate(nick) {
+    const user = this.chat.users.get(nick);
+    if (user.createdDate === '') {
+      return '';
+    }
+    const timeHTML = document.createElement('time');
+    timeHTML.className = 'time';
+    timeHTML.textContent = moment(user.createdDate).format(
+      'Do MMMM, YYYY h:mm a'
+    );
+    timeHTML.setAttribute('datetime', user.createdDate);
+    return timeHTML;
   }
 
   buildFeatures(nick, messageFeatures) {

--- a/assets/chat/js/user.js
+++ b/assets/chat/js/user.js
@@ -5,10 +5,12 @@ class ChatUser {
     if (typeof args === 'string') {
       this.nick = args;
       this.username = args;
+      this.createdDate = args;
       this.features = [];
     } else {
       this.nick = args.nick || '';
       this.username = args.nick || '';
+      this.createdDate = args.createdDate || '';
       this.features = args.features || [];
     }
   }

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -218,9 +218,10 @@
         <h5><span>User Info</span> <i class="chat-menu-close"></i></h5>
       </div>
       <div class="user-info">
-        <h5>Flairs:</h5>
+        <h5 class="date-subheader"></h5>
+        <h5 class="flairs-subheader">Flairs:</h5>
         <div class="flairs"></div>
-        <h5>Selected messages:</h5>
+        <h5 class="stalk-subheader">Selected messages:</h5>
         <div class="stalk">
           <div class="scrollable nano">
             <div class="content nano-content"></div>


### PR DESCRIPTION
As it says in the title, shows the account creation date like this:

![ksnip_20221111-145041](https://user-images.githubusercontent.com/41237021/201381040-5d321244-847a-43b7-a190-1502f2f83c32.png)
![ksnip_20221111-145021](https://user-images.githubusercontent.com/41237021/201381046-d83bb74e-b177-4d3a-a4ef-201fc7c2bbd5.png)

Needs https://github.com/destinygg/chat-private/pull/3 merged to function.