### PR TITLE
fix: history loading after chat connect

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -758,7 +758,7 @@ class Chat {
   }
 
   async loadHistory() {
-    fetch(`${this.config.api.base}/api/chat/history`)
+    return fetch(`${this.config.api.base}/api/chat/history`)
       .then((res) => res.json())
       .then((json) => {
         this.setHistory(json);


### PR DESCRIPTION
Just had to add back the ```return``` that got removed with the lint commit (https://github.com/destinygg/chat-gui/commit/594f1290cdff1318845fab073486334566454d46) :smiley: 
