### PR TITLE
Update old logic for removing /me from messages

### DIFF
--- a/assets/chat/js/messages/ChatMessage.js
+++ b/assets/chat/js/messages/ChatMessage.js
@@ -53,10 +53,7 @@ export default class ChatMessage extends ChatUIMessage {
 
   buildMessageTxt(chat) {
     // TODO we strip off the `/me ` of every message -- must be a better way to do this
-    let msg =
-      this.message.substring(0, 4).toLowerCase() === '/me '
-        ? this.message.substring(4)
-        : this.message;
+    let msg = this.message.replace(/^(\/me\s{1})/i, '');
     if (!this.unformatted)
       formatters.forEach((f) => {
         msg = f.format(chat, msg, this);

--- a/assets/chat/js/messages/ChatMessage.js
+++ b/assets/chat/js/messages/ChatMessage.js
@@ -52,7 +52,6 @@ export default class ChatMessage extends ChatUIMessage {
   }
 
   buildMessageTxt(chat) {
-    // TODO we strip off the `/me ` of every message -- must be a better way to do this
     let msg = this.message.replace(/^(\/me\s{1})/i, '');
     if (!this.unformatted)
       formatters.forEach((f) => {


### PR DESCRIPTION
Been looking through the code and found a TODO lingering there so I thought I'd update it!

Performs a regex replace on the string, replacing found matches with nothing. 
Looks for /me where it's the beginning of a string, is followed by exactly 1 whitespace character and regardless of case.

Did some testing  and all the results seemed to appear as they should. 