### PR TITLE
fix: t5 names hiding on hover in user list (#84)

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -1038,7 +1038,7 @@ hr {
         }
       }
     }
-    .user {
+    .user-entry {
       margin: 0;
       cursor: pointer;
       padding: 0 $gutter-lg;
@@ -1089,10 +1089,10 @@ hr {
   .scrollable {
     max-height: calc(100% - 3em);
   }
-  &.search-in .user {
+  &.search-in .user-entry {
     display: none;
   }
-  &.search-in .user.found {
+  &.search-in .user-entry.found {
     display: flex;
   }
   input {

--- a/assets/chat/js/menus/ChatUserMenu.js
+++ b/assets/chat/js/menus/ChatUserMenu.js
@@ -206,7 +206,7 @@ export default class ChatUserMenu extends ChatMenu {
   }
 
   removeElement(username) {
-    this.container.find(`.user[data-username="${username}"]`).remove();
+    this.container.find(`.user-entry[data-username="${username}"]`).remove();
     this.totalcount -= 1;
   }
 
@@ -217,7 +217,7 @@ export default class ChatUserMenu extends ChatMenu {
     const features =
       user.features.length === 0 ? 'nofeature' : user.features.join(' ');
     const usr = $(
-      `<a data-username="${user.username}" class="user ${features}">${label}<div class="user-actions"><i class="mention-nick"></i><i class="whisper-nick"></i></div></a>`
+      `<div class="user-entry" data-username="${user.username}"><a class="user ${features}">${label}</a><div class="user-actions"><i class="mention-nick"></i><i class="whisper-nick"></i></div></div>`
     );
     const section = this.sections.get(this.highestSection(user));
 
@@ -241,7 +241,9 @@ export default class ChatUserMenu extends ChatMenu {
   }
 
   hasElement(username) {
-    return this.container.find(`.user[data-username="${username}"]`).length > 0;
+    return (
+      this.container.find(`.user-entry[data-username="${username}"]`).length > 0
+    );
   }
 
   filter() {
@@ -263,7 +265,7 @@ export default class ChatUserMenu extends ChatMenu {
         });
       });
     } else {
-      this.container.children('.user').removeClass('found');
+      this.container.children('.user-entry').removeClass('found');
     }
   }
 


### PR DESCRIPTION
Not really sure about this one, I just wrapped everything in a div so that the background on hover stops interfering with the gradient.
Ideally there's some simple CSS fix you can do instead, but I couldn't find it :disappointed: 

I don't think this breaks anything, but definitely needs a lil bit more testing :smile: @Mitchdev @11k 