### PR TITLE
Fix error when attempting to publish package to registry in workflow

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14
+          registry-url: https://registry.npmjs.org
 
       - name: Bump version
         id: bump


### PR DESCRIPTION
There are [some](https://github.com/npm/cli/issues/1637#issuecomment-802178240) [reports](https://github.com/tabhero/svelte-components/issues/1) that explicitly defining this option fixes the issue.