### PR TITLE
Fixed nick message regex

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -30,7 +30,7 @@ import makeSafeForRegex from './regex';
 
 const regexslashcmd = /^\/([a-z0-9]+)[\s]?/i;
 const regextime = /(\d+(?:\.\d*)?)([a-z]+)?/gi;
-const nickmessageregex = /@?(\w{3,20})/g;
+const nickmessageregex = /(?=@?)(\w{3,20})/g;
 const nickregex = /^[a-zA-Z0-9_]{3,20}$/;
 const nsfwnsflregex = /\b(?:NSFL|NSFW)\b/i;
 const nsfwregex = /\b(?:NSFW)\b/i;


### PR DESCRIPTION
Previously included the @ when matched so when it looked for the name it couldn't find it. (@name != name).

https://github.com/destinygg/chat-gui/blob/master/assets/chat/js/chat.js#L974

@11k 