### PR TITLE
Show aliases in /help

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1726,10 +1726,9 @@ class Chat {
   cmdHELP() {
     let str = `Available commands: \r`;
     commandsinfo.forEach((a, k) => {
-      str +=
-        a.alias !== undefined
-          ? ` /${k}, /${a.alias.join(', /')} - ${a.desc} \r`
-          : ` /${k} - ${a.desc} \r`;
+      str += a.alias
+        ? ` /${k}, /${a.alias.join(', /')} - ${a.desc} \r`
+        : ` /${k} - ${a.desc} \r`;
     });
     MessageBuilder.info(str).into(this);
   }

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1726,7 +1726,10 @@ class Chat {
   cmdHELP() {
     let str = `Available commands: \r`;
     commandsinfo.forEach((a, k) => {
-      str += ` /${k} - ${a.desc} \r`;
+      str +=
+        a.alias !== undefined
+          ? ` /${k}, /${a.alias.join(', /')} - ${a.desc} \r`
+          : ` /${k} - ${a.desc} \r`;
     });
     MessageBuilder.info(str).into(this);
   }


### PR DESCRIPTION
Small change, think it would be nice to show aliases, had people ask me why /pe (alias for /postembed) wasn't in /help :smiley: 

<details>
  <summary>Before</summary>

![ksnip_20230107-170236](https://user-images.githubusercontent.com/41237021/211179816-e5f28f7b-8d4a-468f-9e3e-8e199459b7b2.png)
</details>

<details>
  <summary>After</summary>

![ksnip_20230107-170140](https://user-images.githubusercontent.com/41237021/211179849-554d6cb7-16de-45a5-b1b1-d9e1d1051db2.png)
</details>