### PR TITLE
Replace nanoscroller with OverlayScrollbars/some other scrolling performance improvements

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -1348,61 +1348,95 @@ hr {
   display: block;
 }
 
-/* Nano */
-.nano {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
+/* OverlayScrollbars theme */
+.dgg-scroller-theme.os-scrollbar-horizontal {
+  right: 10px;
+  height: 10px;
 }
 
-.nano > .nano-content {
-  overflow-anchor: none;
-  position: absolute;
-  overflow: scroll;
-  overflow-x: hidden;
-  top: 0;
+.dgg-scroller-theme.os-scrollbar-vertical {
+  bottom: 10px;
+  width: 10px;
+}
+
+.dgg-scroller-theme.os-scrollbar-rtl.os-scrollbar-horizontal {
+  left: 10px;
   right: 0;
-  bottom: 0;
+}
+
+.dgg-scroller-theme.os-scrollbar {
+  padding: 2px;
+  box-sizing: border-box;
+  background: transparent;
+}
+
+.dgg-scroller-theme.os-scrollbar-unusable {
+  background: transparent;
+}
+
+.dgg-scroller-theme.os-scrollbar > .os-scrollbar-track {
+  background: transparent;
+}
+
+.dgg-scroller-theme.os-scrollbar-horizontal
+  > .os-scrollbar-track
+  > .os-scrollbar-handle {
+  min-width: 30px;
+}
+
+.dgg-scroller-theme.os-scrollbar-vertical
+  > .os-scrollbar-track
+  > .os-scrollbar-handle {
+  min-height: 30px;
+}
+
+.dgg-scroller-theme.os-scrollbar-transition
+  > .os-scrollbar-track
+  > .os-scrollbar-handle {
+  transition: background-color 0.3s;
+}
+
+.dgg-scroller-theme.os-scrollbar > .os-scrollbar-track > .os-scrollbar-handle {
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.dgg-scroller-theme.os-scrollbar:hover
+  > .os-scrollbar-track
+  > .os-scrollbar-handle {
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.dgg-scroller-theme.os-scrollbar
+  > .os-scrollbar-track
+  > .os-scrollbar-handle.active {
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.dgg-scroller-theme.os-scrollbar-horizontal .os-scrollbar-handle:before,
+.dgg-scroller-theme.os-scrollbar-vertical .os-scrollbar-handle:before {
+  content: '';
+  position: absolute;
   left: 0;
-}
-
-.nano > .nano-content:focus {
-  outline: none;
-}
-
-.nano > .nano-content::-webkit-scrollbar {
-  display: none;
-}
-
-.has-scrollbar > .nano-content::-webkit-scrollbar {
+  right: 0;
+  top: 0;
+  bottom: 0;
   display: block;
 }
 
-.nano > .nano-pane {
-  background: transparent;
-  position: absolute;
-  width: $gutter-md;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  visibility: hidden \9; /* Target only IE7 and IE8 with this hack */
-  opacity: 0.01;
-  transition: 0.2s;
+.dgg-scroller-theme.os-scrollbar-horizontal .os-scrollbar-handle:before {
+  top: -6px;
+  bottom: -2px;
 }
 
-.nano > .nano-pane > .nano-slider {
-  opacity: 0.5;
-  background: $color-surface-light2;
-  position: relative;
-  border-radius: 0;
+.dgg-scroller-theme.os-scrollbar-vertical .os-scrollbar-handle:before {
+  left: -6px;
+  right: -2px;
 }
 
-.nano:hover > .nano-pane,
-.nano-pane.active,
-.nano-pane.flashed {
-  visibility: visible \9; /* Target only IE7 and IE8 with this hack */
-  opacity: 0.99;
+.dgg-scroller-theme.os-scrollbar-rtl.os-scrollbar-vertical
+  .os-scrollbar-handle:before {
+  right: -6px;
+  left: -2px;
 }
 
 /** Form Controls */
@@ -1497,7 +1531,7 @@ button.btn {
   }
 
   .continue,
-  .nano-slider {
+  .os-scrollbar {
     visibility: hidden !important;
   }
 

--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -895,6 +895,7 @@ hr {
   }
   .scrollable {
     flex: 1;
+    height: 100%;
   }
   &.active {
     display: block;

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -693,7 +693,7 @@ class Chat {
       const nick = $(e.currentTarget).closest('.msg-user').data('username');
       this.getActiveWindow()
         .getlines(`.censored[data-username="${nick}"]`)
-        .removeClass('censored');
+        .forEach((line) => line.classList.remove('censored'));
       return false;
     });
 
@@ -1141,10 +1141,10 @@ class Chat {
     );
     switch (parseInt(this.settings.get('showremoved') || 1, 10)) {
       case 0: // remove
-        c.remove();
+        c.forEach((line) => line.remove());
         break;
       case 1: // censor
-        c.addClass('censored');
+        c.forEach((line) => line.classList.add('censored'));
         break;
       case 2: // do nothing
       default:
@@ -2058,10 +2058,19 @@ class Chat {
 
     this.mainwindow
       .getlines(`.msg-user[data-username="${n}"]`)
-      .removeClass(Chat.removeClasses('msg-tagged'))
-      .addClass(`msg-tagged msg-tagged-${color}`)
-      .find('.user')
-      .attr('title', note);
+      .forEach((line) => {
+        const classesToRemove = Chat.removeClasses(
+          'msg-tagged',
+          line.classList.value
+        );
+        classesToRemove.forEach((className) =>
+          line.classList.remove(className)
+        );
+        ['msg-tagged', `msg-tagged-${color}`].forEach((tag) =>
+          line.classList.add(tag)
+        );
+        line.querySelector('.user').title = note;
+      });
 
     this.taggednicks.set(n, color);
     this.taggednotes.set(n, note);
@@ -2097,10 +2106,17 @@ class Chat {
     const n = parts[0].toLowerCase();
 
     this.mainwindow
-      .getlines(`.msg-chat[data-username="${n}"]`)
-      .removeClass(Chat.removeClasses('msg-tagged'))
-      .find('.user')
-      .removeAttr('title');
+      .getlines(`.msg-user[data-username="${n}"]`)
+      .forEach((line) => {
+        const classesToRemove = Chat.removeClasses(
+          'msg-tagged',
+          line.classList.value
+        );
+        classesToRemove.forEach((className) =>
+          line.classList.remove(className)
+        );
+        line.querySelector('.user').removeAttribute('title');
+      });
 
     this.taggednicks.delete(n);
     this.taggednotes.delete(n);
@@ -2665,9 +2681,10 @@ class Chat {
     return [...uniqueNicks];
   }
 
-  static removeClasses(search) {
-    return (i, c) =>
-      (c.match(new RegExp(`\\b${search}(?:[A-z-]+)?\\b`, 'g')) || []).join(' ');
+  static removeClasses(search, classList) {
+    return (
+      classList.match(new RegExp(`\\b${search}(?:[A-z-]+)?\\b`, 'g')) || []
+    );
   }
 
   static isArraysEqual(a, b) {

--- a/assets/chat/js/menus/ChatMenu.js
+++ b/assets/chat/js/menus/ChatMenu.js
@@ -10,7 +10,7 @@ export default class ChatMenu extends EventEmitter {
     this.visible = false;
     this.shown = false;
     this.ui.find('.scrollable').each((i, e) => {
-      this.scrollplugin = new ChatScrollPlugin(chat, e);
+      this.scrollplugin = new ChatScrollPlugin(e.querySelector('.content'), e);
     });
     this.ui.on('click', '.close,.chat-menu-close', this.hide.bind(this));
     this.btn.on('click', (e) => {

--- a/assets/chat/js/messages/ChatEmoteMessage.js
+++ b/assets/chat/js/messages/ChatEmoteMessage.js
@@ -14,7 +14,10 @@ function ChatEmoteMessageCount(message) {
   else if (message.emotecount >= 5) stepClass = ' x5';
   message.combo.attr('class', `chat-combo${stepClass}`);
   message.combo_count.text(`${message.emotecount}`);
-  message.ui.append(message.text.detach(), message.combo.detach());
+  message.ui.append(
+    message.text.detach().get(0),
+    message.combo.detach().get(0)
+  );
 }
 const ChatEmoteMessageCountThrottle = throttle(63, ChatEmoteMessageCount);
 
@@ -51,7 +54,7 @@ export default class ChatEmoteMessage extends ChatMessage {
       ' ',
       this.combo_txt
     );
-    this.ui.append(this.text, this.combo);
+    this.ui.append(this.text.get(0), this.combo.get(0));
   }
 
   incEmoteCount() {

--- a/assets/chat/js/messages/ChatUIMessage.js
+++ b/assets/chat/js/messages/ChatUIMessage.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import MessageTypes from './MessageTypes';
 
 export default class ChatUIMessage {
@@ -22,9 +21,14 @@ export default class ChatUIMessage {
     classes.push(this.classes);
     classes.unshift(`msg-${this.type.toLowerCase()}`);
     classes.unshift(`msg-chat`);
-    return $('<div></div>', { ...attr, class: classes.join(' ') }).html(
-      content
-    )[0].outerHTML;
+
+    const wrapped = document.createElement('div');
+    Object.assign(wrapped, {
+      ...attr,
+      className: classes.join(' '),
+    });
+    wrapped.innerHTML = content;
+    return wrapped;
   }
 
   // eslint-disable-next-line no-unused-vars

--- a/assets/chat/js/messages/ChatUIMessage.js
+++ b/assets/chat/js/messages/ChatUIMessage.js
@@ -23,10 +23,10 @@ export default class ChatUIMessage {
     classes.unshift(`msg-chat`);
 
     const wrapped = document.createElement('div');
-    Object.assign(wrapped, {
-      ...attr,
-      className: classes.join(' '),
-    });
+    wrapped.className = classes.join(' ');
+    Object.entries(attr).forEach(([key, value]) =>
+      wrapped.setAttribute(key, value)
+    );
     wrapped.innerHTML = content;
     return wrapped;
   }

--- a/assets/chat/js/scroll.js
+++ b/assets/chat/js/scroll.js
@@ -1,46 +1,78 @@
 import $ from 'jquery';
-import 'nanoscroller';
+// eslint-disable-next-line import/no-unresolved
+import 'overlayscrollbars/overlayscrollbars.css';
+import { OverlayScrollbars } from 'overlayscrollbars';
 
 const isTouchDevice =
   'ontouchstart' in window || // works on most browsers
   navigator.maxTouchPoints; // works on IE10/11 and Surface
 
 class ChatScrollPlugin {
-  constructor(chat, e) {
-    const el = $(e).get(0);
-    if (!el) return;
+  constructor(viewport, target = undefined) {
+    this.viewportEl = $(viewport).get(0);
+    if (!this.viewportEl) return;
 
-    const $el = $(e);
-    if ($el.find('.chat-scroll-notify').length > 0) {
-      $el.on('update', () =>
-        $el.toggleClass('chat-unpinned', !this.isPinned())
-      ); // debounce
-      $el.on('click', '.chat-scroll-notify', () => {
+    this.previousPosition = 0;
+
+    const targetEl = target !== undefined ? $(target) : $(viewport);
+
+    this.scroller = OverlayScrollbars(
+      {
+        target: targetEl.get(0),
+        elements: {
+          viewport: this.viewportEl,
+        },
+      },
+      {
+        scrollbars: {
+          theme: 'dgg-scroller-theme',
+          autoHide: isTouchDevice ? 'never' : 'move',
+          autoHideDelay: 1000,
+        },
+      }
+    );
+    this.viewport = this.scroller.elements().viewport;
+    if (targetEl.find('.chat-scroll-notify').length > 0) {
+      this.scroller.on('scroll', () => {
+        const direction = this.getScrollDirection();
+        this.previousPosition = this.viewportEl.scrollTop;
+        if (direction !== 'same') {
+          targetEl.toggleClass('chat-unpinned', !this.isPinned());
+        }
+      });
+      targetEl.on('click', '.chat-scroll-notify', () => {
         this.updateAndPin(true);
         return false;
       });
     }
-    this.scroller = $el.nanoScroller({
-      sliderMinHeight: 40,
-      disableResize: true,
-      alwaysVisible: isTouchDevice,
-    })[0].nanoscroller;
+  }
+
+  getScrollDirection() {
+    if (this.viewportEl.scrollTop > this.previousPosition) {
+      return 'down';
+    }
+    if (this.viewportEl.scrollTop < this.previousPosition) {
+      return 'up';
+    }
+    return 'same';
   }
 
   isPinned() {
     // 30 is used to allow the scrollbar to be just offset, but still count as scrolled to bottom
-    return !this.scroller.isActive
-      ? true
-      : this.scroller.contentScrollTop >= this.scroller.maxScrollTop - 30;
+    const { scrollTop, scrollHeight, clientHeight } = this.viewport;
+    return scrollTop >= scrollHeight - clientHeight - 30;
   }
 
   updateAndPin(pin) {
-    this.reset();
-    if (pin) this.scroller.scrollBottom(0);
+    if (pin) this.scrollBottom();
+  }
+
+  scrollBottom() {
+    this.viewport.scrollTo(0, this.viewport.scrollHeight);
   }
 
   reset() {
-    this.scroller.reset();
+    this.scroller.update();
   }
 
   destroy() {

--- a/assets/chat/js/window.js
+++ b/assets/chat/js/window.js
@@ -27,8 +27,8 @@ class ChatWindow extends EventEmitter {
     this.tag = null;
     this.lastmessage = null;
     this.ui = $(
-      `<div id="chat-win-${name}" class="chat-output ${type} nano" style="display: none;">` +
-        `<div class="chat-lines nano-content"></div>` +
+      `<div id="chat-win-${name}" class="chat-output ${type}" style="display: none;">` +
+        `<div class="chat-lines"></div>` +
         `<div class="chat-scroll-notify">More messages below</div>` +
         `</div>`
     );
@@ -44,7 +44,10 @@ class ChatWindow extends EventEmitter {
   into(chat) {
     const normalized = this.name.toLowerCase();
     this.maxlines = chat.settings.get('maxlines');
-    this.scrollplugin = new ChatScrollPlugin(chat, this.ui);
+    this.scrollplugin = new ChatScrollPlugin(
+      this.lines.get(0),
+      this.lines.get(0).parentElement
+    );
     this.tag =
       chat.taggednicks.get(normalized) ||
       tagcolors[Math.floor(Math.random() * tagcolors.length)];

--- a/assets/chat/js/window.js
+++ b/assets/chat/js/window.js
@@ -83,11 +83,11 @@ class ChatWindow extends EventEmitter {
   }
 
   getlines(sel) {
-    return this.lines.children.querySelectorAll(sel);
+    return this.lines.querySelectorAll(sel);
   }
 
   removelines(sel) {
-    const remove = this.lines.children.querySelectorAll(sel);
+    const remove = this.lines.querySelectorAll(sel);
     this.linecount -= remove.length;
     remove.forEach((element) => {
       element.remove();

--- a/assets/chat/js/window.js
+++ b/assets/chat/js/window.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import { throttle } from 'throttle-debounce';
 import ChatScrollPlugin from './scroll';
 import EventEmitter from './emitter';
 
@@ -78,7 +79,7 @@ class ChatWindow extends EventEmitter {
     this.lastmessage = message;
     this.lines.append(message.ui);
     this.linecount += 1;
-    this.cleanup();
+    this.cleanupThrottle();
   }
 
   getlines(sel) {
@@ -125,6 +126,8 @@ class ChatWindow extends EventEmitter {
       }
     }
   }
+
+  cleanupThrottle = throttle(50, this.cleanup);
 
   updateAndPin(pin = true) {
     this.scrollplugin.updateAndPin(pin);

--- a/assets/chat/js/window.js
+++ b/assets/chat/js/window.js
@@ -32,7 +32,7 @@ class ChatWindow extends EventEmitter {
         `<div class="chat-scroll-notify">More messages below</div>` +
         `</div>`
     );
-    this.lines = this.ui.find('.chat-lines');
+    this.lines = this.ui.get(0).querySelector('.chat-lines');
   }
 
   destroy() {
@@ -45,8 +45,8 @@ class ChatWindow extends EventEmitter {
     const normalized = this.name.toLowerCase();
     this.maxlines = chat.settings.get('maxlines');
     this.scrollplugin = new ChatScrollPlugin(
-      this.lines.get(0),
-      this.lines.get(0).parentElement
+      this.lines,
+      this.lines.parentElement
     );
     this.tag =
       chat.taggednicks.get(normalized) ||
@@ -73,7 +73,7 @@ class ChatWindow extends EventEmitter {
   }
 
   addMessage(chat, message) {
-    message.ui = $(message.html(chat));
+    message.ui = message.html(chat);
     message.afterRender(chat);
     this.lastmessage = message;
     this.lines.append(message.ui);
@@ -82,13 +82,15 @@ class ChatWindow extends EventEmitter {
   }
 
   getlines(sel) {
-    return this.lines.children(sel);
+    return this.lines.children.querySelectorAll(sel);
   }
 
   removelines(sel) {
-    const remove = this.lines.children(sel);
+    const remove = this.lines.children.querySelectorAll(sel);
     this.linecount -= remove.length;
-    remove.remove();
+    remove.forEach((element) => {
+      element.remove();
+    });
   }
 
   locked() {
@@ -113,11 +115,13 @@ class ChatWindow extends EventEmitter {
   // Get the scroll position before adding the new line / removing old lines
   cleanup() {
     if (this.scrollplugin.isPinned() || this.waspinned) {
-      const lines = this.lines.children();
+      const lines = [...this.lines.children];
       if (lines.length >= this.maxlines) {
         const remove = lines.slice(0, lines.length - this.maxlines);
         this.linecount -= remove.length;
-        remove.remove();
+        remove.forEach((element) => {
+          element.remove();
+        });
       }
     }
   }

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -41,8 +41,8 @@
       <div class="toolbar">
         <h5><span>Settings</span> <i class="chat-menu-close"></i></h5>
       </div>
-      <div class="scrollable nano">
-        <div class="content nano-content">
+      <div class="scrollable">
+        <div class="content">
           <div id="chat-settings-form">
             <div class="form-group checkbox">
               <label title="Persistent profile settings">
@@ -198,8 +198,8 @@
       <div class="toolbar">
         <h5><span>Users</span> <i class="chat-menu-close"></i></h5>
       </div>
-      <div class="scrollable nano">
-        <div class="content nano-content"></div>
+      <div class="scrollable">
+        <div class="content"></div>
       </div>
       <div id="chat-user-list-search">
         <input
@@ -223,8 +223,8 @@
         <div class="flairs"></div>
         <h5 class="stalk-subheader">Selected messages:</h5>
         <div class="stalk">
-          <div class="scrollable nano">
-            <div class="content nano-content"></div>
+          <div class="scrollable">
+            <div class="content"></div>
           </div>
         </div>
       </div>
@@ -266,8 +266,8 @@
       <div class="toolbar">
         <h5><span>Emotes</span> <i class="chat-menu-close"></i></h5>
       </div>
-      <div class="scrollable nano">
-        <div class="content nano-content"></div>
+      <div class="scrollable">
+        <div class="content"></div>
       </div>
       <div id="chat-emote-list-search">
         <input
@@ -285,8 +285,8 @@
       <div class="toolbar">
         <h5><span>Whispers</span> <i class="chat-menu-close"></i></h5>
       </div>
-      <div class="scrollable nano">
-        <div class="content nano-content">
+      <div class="scrollable">
+        <div class="content">
           <ul></ul>
         </div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "dgg-chat-gui",
-      "version": "2.18.0",
+      "version": "2.20.0",
       "license": "SEE LICENSE IN <LICENSE.md>",
       "dependencies": {
         "jquery": "^3.6.0",
         "moment": "~2.29.1",
-        "nanoscroller": "~0.8.7",
         "normalize.css": "~8.0.1",
+        "overlayscrollbars": "^2.0.3",
         "sass-loader": "^11.1.1",
         "throttle-debounce": "~3.0.1",
         "whatwg-fetch": "^3.6.2"
@@ -3183,6 +3183,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true,
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -4550,16 +4551,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.6.0"
-      }
-    },
     "node_modules/css-loader": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.5.tgz",
@@ -4657,14 +4648,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/cssesc": {
@@ -4780,6 +4763,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7616,7 +7600,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/internal-ip": {
       "version": "4.3.0",
@@ -11287,15 +11272,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/nanoscroller": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/nanoscroller/-/nanoscroller-0.8.7.tgz",
-      "integrity": "sha1-gpXQ6ZO71UxEMGsOuzAKhD9zv5I=",
-      "dependencies": {
-        "css": "*",
-        "jquery": ">=1.6"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -11773,6 +11749,11 @@
       "dependencies": {
         "url-parse": "^1.4.3"
       }
+    },
+    "node_modules/overlayscrollbars": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.0.3.tgz",
+      "integrity": "sha512-boOkJFER1Tc21sxF4a7ghGl+ETV3WtP7YgsUyDPo1VTHUIPdQLfnTzMyOOdMkKkVcpJOYMKwwr4m+saCtgawCg=="
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
@@ -13618,15 +13599,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-resolve": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0"
       }
     },
     "node_modules/source-map-support": {
@@ -18576,7 +18548,8 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
     },
     "autoprefixer": {
       "version": "10.2.5",
@@ -19673,23 +19646,6 @@
         "which": "^2.0.1"
       }
     },
-    "css": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-      "requires": {
-        "inherits": "^2.0.4",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
     "css-loader": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.5.tgz",
@@ -19847,7 +19803,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "dedent": {
       "version": "0.7.0",
@@ -22037,7 +21994,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "internal-ip": {
       "version": "4.3.0",
@@ -24794,15 +24752,6 @@
         "to-regex": "^3.0.1"
       }
     },
-    "nanoscroller": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/nanoscroller/-/nanoscroller-0.8.7.tgz",
-      "integrity": "sha1-gpXQ6ZO71UxEMGsOuzAKhD9zv5I=",
-      "requires": {
-        "css": "*",
-        "jquery": ">=1.6"
-      }
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -25177,6 +25126,11 @@
       "requires": {
         "url-parse": "^1.4.3"
       }
+    },
+    "overlayscrollbars": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.0.3.tgz",
+      "integrity": "sha512-boOkJFER1Tc21sxF4a7ghGl+ETV3WtP7YgsUyDPo1VTHUIPdQLfnTzMyOOdMkKkVcpJOYMKwwr4m+saCtgawCg=="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -26604,15 +26558,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
       "dev": true
-    },
-    "source-map-resolve": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-      "requires": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0"
-      }
     },
     "source-map-support": {
       "version": "0.5.19",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "dependencies": {
     "jquery": "^3.6.0",
     "moment": "~2.29.1",
-    "nanoscroller": "~0.8.7",
     "normalize.css": "~8.0.1",
+    "overlayscrollbars": "^2.0.3",
     "sass-loader": "^11.1.1",
     "throttle-debounce": "~3.0.1",
     "whatwg-fetch": "^3.6.2"


### PR DESCRIPTION
Swaps out the ancient unmaintained nanoscroller plugin with the shiny new OverlayScrollbars plugin :smile: Based on my, admittedly, unscientific test (spamming chat with 4x1000 generated MSG events to make it lag), this improves performance a decent amount (time decrease of 22.12%):

<details>
    <summary>Performance comparison 1</summary>

- nanoscroller:
![old](https://user-images.githubusercontent.com/41237021/211180354-2576be0e-1e64-4184-ad9f-5c80d4415b60.png)
- OverlayScrollbars:
![new](https://user-images.githubusercontent.com/41237021/211180356-210c4542-51e9-40b4-bbab-bea313a82728.png)
</details>

Visually, I made it look and behave similarly to the old scrollbar (just a gray rectangle that auto-hides on PC and is always shown on mobile):

<details>
    <summary>Scrollbar look</summary>

- nanoscroller:
![image](https://user-images.githubusercontent.com/41237021/211180596-5d868ac3-7277-47de-a746-f90ac65c44aa.png)
- OverlayScrollbars:
![image](https://user-images.githubusercontent.com/41237021/211180577-2e0d4a80-54c9-43db-951c-c460844ee585.png)
</details>

In addition to that, by swapping out some jQuery DOM manipulation stuff with native DOM manip stuff, we get another performance boost (17.55% faster compared to the only OverlayScrollbars version):

<details>
    <summary>jQuery -> native</summary>

![ksnip_20230107-163623](https://user-images.githubusercontent.com/41237021/211180497-a3b949c4-f116-49a4-95f1-99316dc3e84e.png)

</details>

Finally, by adding a small throttle to the chat cleanup function, we get the last performance improvement (26.06% faster compared to the "jQuery -> native" version), but, admittedly, I haven't tested if it changes the chat experience much (it shouldn't, I think):

<details>
    <summary>Throttle</summary>

![ksnip_20230107-163636](https://user-images.githubusercontent.com/41237021/211180393-6a6dcf9c-8374-4e35-9f33-107bd766ed9d.png)
</details>