### PR TITLE
Add check to avoid closing menus on resizing on mobile screens

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -664,6 +664,12 @@ class Chat {
       this.focusIfNothingSelected();
     });
     const onresize = () => {
+      // If this is a mobile screen, don't close menus.
+      // The virtual keyboard triggers a 'resize' event, and menus shouldn't be closed whenever the virtual keyboard is opened
+      if (window.screen.width <= 768) {
+        return;
+      }
+
       if (!resizing) {
         resizing = true;
         ChatMenu.closeMenus(this);


### PR DESCRIPTION
On android mobile screens, if you focus an input it brings up the virtual keyboard, which constitutes a `resize` event.
This causes weird bugs with the menus, for instance bringing up the users menu automatically focuses its user-search field, bringing up the virtual keyboard, causing a `resize` event which immediately closes the menu you just opened.
On the chrome app on android, this actually crashes the page.

I can't test this, but I think ios keyboard overlaps and doesn't cause a `resize` event. So this might only be a bug for android phones.

### Reproduce Bug
1. Open DGG on a mobile version (one with an actual virtual keyboard, not just the chrome devtools version)
2. Open the emotes or users menu
4. The keyboard causes the menu to close, not allowing you to type anything

### Fix
I added a check to avoid the resizing logic for mobile screens.
I couldn't think of a situation on the mobile version of the site where the resize logic would legitimately be triggered. If there are such situations, then this code might cause issues. As far as I could tell, though, you can't really resize anything on mobile DGG.
Maybe there's a better way to detect if it's the virtual keyboard causing the `resize` event?

Also, I had a previous PR also related to mobile screens and the virtual keyboard, but I think this issue isn't related to those changes I made. I see this bug with and without those changes.