### PR TITLE
Shorten long chat links

### DIFF
--- a/assets/chat/js/formatters/UrlFormatter.js
+++ b/assets/chat/js/formatters/UrlFormatter.js
@@ -70,9 +70,15 @@ export default class UrlFormatter {
       const decodedUrl = self.elem.html(url).text();
       const m = decodedUrl.match(self.linkregex);
       if (m) {
-        const encodedUrl = self.encodeUrl(m[0]);
+        let encodedUrl = self.encodeUrl(m[0]);
+        
         const extra = self.encodeUrl(decodedUrl.substring(m[0].length));
         const href = `${scheme ? '' : 'http://'}${encodedUrl}`;
+
+        if (encodedUrl.length > 40) {
+          encodedUrl = `${encodedUrl.substring(0, 39)}...`
+        }
+        
         return `<a target="_blank" class="externallink ${extraclass}" href="${href}" rel="nofollow">${encodedUrl}</a>${extra}`;
       }
       return url;

--- a/assets/chat/js/formatters/UrlFormatter.js
+++ b/assets/chat/js/formatters/UrlFormatter.js
@@ -71,14 +71,22 @@ export default class UrlFormatter {
       const m = decodedUrl.match(self.linkregex);
       if (m) {
         let encodedUrl = self.encodeUrl(m[0]);
-        
+
         const extra = self.encodeUrl(decodedUrl.substring(m[0].length));
         const href = `${scheme ? '' : 'http://'}${encodedUrl}`;
 
-        if (encodedUrl.length > 40) {
-          encodedUrl = `${encodedUrl.substring(0, 39)}...`
+        const maxUrlLength = 90;
+
+        if (encodedUrl.length > maxUrlLength) {
+          const midpoint = Math.ceil(encodedUrl.length / 2);
+          const toRemove = encodedUrl.length - maxUrlLength;
+          const strip = Math.ceil(toRemove / 2);
+          encodedUrl = `${encodedUrl.substring(
+            0,
+            midpoint - strip
+          )}...${encodedUrl.substring(midpoint + strip)}`;
         }
-        
+
         return `<a target="_blank" class="externallink ${extraclass}" href="${href}" rel="nofollow">${encodedUrl}</a>${extra}`;
       }
       return url;


### PR DESCRIPTION
Shorten displayed links in chat that are above 40 characters in length. 

- Checks if `encodedUrl.length` is above 40 characters
- Replaces with substring if true
- Appends an ellipsis to signify shortened url

<img width="990" alt="image" src="https://user-images.githubusercontent.com/9166188/214052426-ddcd6331-5ab6-4855-8e9a-53a9f32be553.png">


resolves: #113