### PR TITLE
Add user's tag note to user info menu.

### DIFF
--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -15,6 +15,8 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
 
     this.createdDateSubheader = this.ui.find('.user-info h5.date-subheader')[0];
 
+    this.tagSubheader = this.ui.find('.user-info h5.tag-subheader')[0];
+
     this.flairList = this.ui.find('.user-info .flairs');
     this.flairSubheader = this.ui.find('.user-info h5.flairs-subheader')[0];
 
@@ -220,6 +222,7 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
 
     const prettyNick = message.find('.user')[0].innerText;
     const nick = message.data('username');
+    const tagNote = this.chat.taggednotes.get(nick);
     const usernameFeatures = message.find('.user')[0].classList.value;
 
     const formattedDate = this.buildCreatedDate(nick);
@@ -231,6 +234,14 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     } else {
       this.createdDateSubheader.style.display = '';
       this.createdDateSubheader.replaceChildren('Joined on ', formattedDate);
+    }
+
+    if (tagNote) {
+      this.tagSubheader.style.display = '';
+      this.tagSubheader.replaceChildren('Tag: ', tagNote);
+    } else {
+      this.tagSubheader.style.display = 'none';
+      this.tagSubheader.replaceChildren();
     }
 
     const featuresList = this.buildFeatures(nick, usernameFeatures);

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -238,6 +238,7 @@
       </div>
       <div class="user-info">
         <h5 class="date-subheader"></h5>
+        <h5 class="tag-subheader"></h5>
         <h5 class="flairs-subheader">Flairs:</h5>
         <div class="flairs"></div>
         <h5 class="stalk-subheader">Selected messages:</h5>


### PR DESCRIPTION
Shows a tagged user's tag note in the user info menu. Only ways to currently see a user's tag note is hovering over their name (which can't be done on mobile browsers) or using the tag command and trying to find their username (which can be annoying if a lot of users have been tagged). If the user doesn't have a tag note (either not tagged at all or just tagged with a color), the line is just hidden.

![Screenshot from 2023-01-30 01-51-23](https://user-images.githubusercontent.com/78668750/215444365-b97e041a-1065-45c1-a907-c16ce125768e.png)
![Screenshot from 2023-01-30 02-06-17](https://user-images.githubusercontent.com/78668750/215447579-189674c6-579f-4e80-b569-322cf4025fb9.png)

