### PR TITLE
Fix embed for YT live share link

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -2201,8 +2201,12 @@ class Chat {
             break;
           case 'www.youtube.com':
           case 'youtube.com': {
-            const params = new URLSearchParams(match[7]);
-            location.href = `${noEmbedUrl}#youtube/${params.get('v')}`;
+            if (match[5] === '/live') {
+              location.href = `${noEmbedUrl}#youtube/${match[6]}`;
+            } else {
+              const params = new URLSearchParams(match[7]);
+              location.href = `${noEmbedUrl}#youtube/${params.get('v')}`;
+            }
             break;
           }
           case 'www.youtu.be':
@@ -2286,8 +2290,12 @@ class Chat {
             break;
           case 'www.youtube.com':
           case 'youtube.com': {
-            const params = new URLSearchParams(match[7]);
-            msg = `#youtube/${params.get('v')}`;
+            if (match[5] === '/live') {
+              msg = `#youtube/${match[6]}`;
+            } else {
+              const params = new URLSearchParams(match[7]);
+              msg = `#youtube/${params.get('v')}`;
+            }
             this.source.send('MSG', { data: `${msg} ${moreMsg}` });
             break;
           }


### PR DESCRIPTION
For live streams, Youtube gives a different URL format when getting a URL from the Share button:
https://www.youtube.com/live/XXXXXXXXX?feature=share
Versus the actual URL for stream:
https://www.youtube.com/watch?v=XXXXXXXXX

This causes the /embed and /postembed commands to output the following embed: #youtube/null
This fix checks for the `/live` part, and if so, grab the correct match part containing the video ID.