### PR TITLE
Hash link converter and `/embed` and `/postembed` refactor

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -2194,7 +2194,7 @@ class Chat {
             'Valid links: Twitch Streams, Twitch VODs, Twitch Clips, Youtube Videos, Rumble Videos.'
           ).into(this);
         } else {
-          MessageBuilder.error(error.message);
+          MessageBuilder.error(error.message).into(this);
         }
       }
     }
@@ -2235,7 +2235,7 @@ class Chat {
             'Valid links: Twitch Streams, Twitch VODs, Twitch Clips, Youtube Videos, Rumble Videos.'
           ).into(this);
         } else {
-          MessageBuilder.error(error.message);
+          MessageBuilder.error(error.message).into(this);
         }
       }
     }

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -2166,10 +2166,8 @@ class Chat {
 
   cmdEMBED(parts) {
     const { location } = window.top || window.parent || window;
-    const noEmbedUrl = location.href.split('#')[0];
     try {
-      const hashLink = this.hashLinkConverter.convert(parts[0]);
-      location.href = `${noEmbedUrl}${hashLink}`;
+      location.hash = this.hashLinkConverter.convert(parts[0]);
     } catch (error) {
       MessageBuilder.error(error.message).into(this);
       MessageBuilder.info(
@@ -2180,21 +2178,16 @@ class Chat {
 
   cmdPOSTEMBED(parts) {
     const { location } = window.top || window.parent || window;
-    const EmbedSplit = location.href.split('#');
-    let moreMsg = '';
     try {
       const hashLink = this.hashLinkConverter.convert(parts[0]);
-      if (parts[1]) {
-        parts.shift();
-        moreMsg = parts.join(' ');
-      }
-      this.source.send('MSG', { data: `${hashLink} ${moreMsg}` });
+      this.source.send('MSG', {
+        data: `${hashLink} ${parts.slice(1).join(' ')}`,
+      });
     } catch (error) {
-      if (EmbedSplit[1]) {
-        if (parts[0]) {
-          moreMsg = parts.join(' ');
-        }
-        this.source.send('MSG', { data: `#${EmbedSplit[1]} ${moreMsg}` });
+      if (location.hash) {
+        this.source.send('MSG', {
+          data: `${location.hash} ${parts.join(' ')}`,
+        });
       } else {
         if (error.message === MISSING_ARG_ERROR) {
           MessageBuilder.error('Nothing embedded').into(this);
@@ -2202,7 +2195,7 @@ class Chat {
           MessageBuilder.error(error.message).into(this);
         }
         MessageBuilder.info(
-          'Usage: /postembed OR /pe OR /postembed <link> [<message>] OR /pe <link> [<message>] (Valid links: Twitch streams, VODs, clips, Youtube, Rumble)'
+          'Usage: /postembed [<link>] [<message>] (Alias: /pe) (Valid links: Twitch streams, VODs, clips, Youtube, Rumble)'
         ).into(this);
       }
     }

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -33,7 +33,7 @@ import { isMuteActive, MutedTimer } from './mutedtimer';
 import EmoteService from './emotes';
 import UserFeatures from './features';
 import makeSafeForRegex from './regex';
-import HashLinkConverter from './hashlinkconverter';
+import { HashLinkConverter } from './hashlinkconverter';
 
 const regexslashcmd = /^\/([a-z0-9]+)[\s]?/i;
 const regextime = /(\d+(?:\.\d*)?)([a-z]+)?/gi;

--- a/assets/chat/js/hashlinkconverter.js
+++ b/assets/chat/js/hashlinkconverter.js
@@ -1,0 +1,54 @@
+export default class HashLinkConverter {
+  constructor() {
+    this.hasHttp = /^http[s]?:\/{0,2}/;
+    this.youtubeLiveRegex = /^live\/([a-zA-z0-9_]{11})$/;
+    this.twitchClipRegex = /^[^/]+\/clip\/([a-zA-z0-9-]*)$/;
+    this.twitchVODRegex = /^videos\/(\d+)$/;
+    this.rumbleEmbedRegex = /^embed\/([a-z0-9]+)\/?$/;
+  }
+
+  convert(urlString) {
+    const url = new URL(
+      // if a url doesn't have a protocol, URL throws an error
+      urlString.match(this.hasHttp) ? urlString : `https://${urlString}`
+    );
+    const pathname = url.pathname.slice(1);
+    let match;
+    switch (url.hostname) {
+      case 'www.twitch.tv':
+      case 'twitch.tv':
+        match = pathname.match(this.twitchClipRegex);
+        if (match) {
+          return `#twitch-clip/${match[1]}`;
+        }
+        match = pathname.match(this.twitchVODRegex);
+        if (match) {
+          return `#twitch-vod/${match[1]}`;
+        }
+        return `#twitch/${pathname}`;
+      case 'clips.twitch.tv':
+        return `#twitch-clip/${pathname}`;
+      case 'www.youtube.com':
+      case 'youtube.com':
+        match = pathname.match(this.youtubeLiveRegex);
+        if (match) {
+          return `#youtube/${match[1]}`;
+        }
+        return `#youtube/${url.searchParams.get('v')}`;
+      case 'www.youtu.be':
+      case 'youtu.be':
+        return `#youtube/${pathname}`;
+      case 'www.rumble.com':
+      case 'rumble.com':
+        match = pathname.match(this.rumbleEmbedRegex);
+        if (match) {
+          return `#rumble/${match[1]}`;
+        }
+        throw new Error(
+          'Rumble links have to be embed links - https://rumble.com/embed/<id>'
+        );
+      default:
+        throw new Error('Invalid link');
+    }
+  }
+}

--- a/assets/chat/js/hashlinkconverter.js
+++ b/assets/chat/js/hashlinkconverter.js
@@ -1,4 +1,10 @@
-export default class HashLinkConverter {
+const RUMBLE_EMBED_ERROR =
+  'Rumble links have to be embed links - https://rumble.com/embed/<id>';
+const MISSING_ARG_ERROR = 'Missing argument';
+const INVALID_LINK_ERROR = 'Invalid link';
+const MISSING_VIDEO_ID_ERROR = 'Invalid Youtube link - Missing video id';
+
+class HashLinkConverter {
   constructor() {
     this.hasHttp = /^http[s]?:\/{0,2}/;
     this.youtubeLiveRegex = /^live\/([a-zA-z0-9_]{11})$/;
@@ -8,6 +14,9 @@ export default class HashLinkConverter {
   }
 
   convert(urlString) {
+    if (!urlString) {
+      throw new Error(MISSING_ARG_ERROR);
+    }
     const url = new URL(
       // if a url doesn't have a protocol, URL throws an error
       urlString.match(this.hasHttp) ? urlString : `https://${urlString}`
@@ -37,7 +46,7 @@ export default class HashLinkConverter {
         }
         videoId = url.searchParams.get('v');
         if (!videoId) {
-          throw new Error('Invalid link');
+          throw new Error(MISSING_VIDEO_ID_ERROR);
         }
         return `#youtube/${videoId}`;
       case 'www.youtu.be':
@@ -49,11 +58,17 @@ export default class HashLinkConverter {
         if (match) {
           return `#rumble/${match[1]}`;
         }
-        throw new Error(
-          'Rumble links have to be embed links - https://rumble.com/embed/<id>'
-        );
+        throw new Error(RUMBLE_EMBED_ERROR);
       default:
-        throw new Error('Invalid link');
+        throw new Error(INVALID_LINK_ERROR);
     }
   }
 }
+
+export {
+  HashLinkConverter,
+  RUMBLE_EMBED_ERROR,
+  INVALID_LINK_ERROR,
+  MISSING_VIDEO_ID_ERROR,
+  MISSING_ARG_ERROR,
+};

--- a/assets/chat/js/hashlinkconverter.js
+++ b/assets/chat/js/hashlinkconverter.js
@@ -14,6 +14,7 @@ export default class HashLinkConverter {
     );
     const pathname = url.pathname.slice(1);
     let match;
+    let videoId;
     switch (url.hostname) {
       case 'www.twitch.tv':
       case 'twitch.tv':
@@ -34,7 +35,11 @@ export default class HashLinkConverter {
         if (match) {
           return `#youtube/${match[1]}`;
         }
-        return `#youtube/${url.searchParams.get('v')}`;
+        videoId = url.searchParams.get('v');
+        if (!videoId) {
+          throw new Error('Invalid link');
+        }
+        return `#youtube/${videoId}`;
       case 'www.youtu.be':
       case 'youtu.be':
         return `#youtube/${pathname}`;

--- a/assets/chat/js/hashlinkconverter.test.js
+++ b/assets/chat/js/hashlinkconverter.test.js
@@ -38,9 +38,9 @@ describe('Valid embeds', () => {
       'https://rumble.com/embed/v26pcdc/?pub=4',
       '#rumble/v26pcdc',
     ],
-  ])('%s', (_, url, expectedHash) => {
-    const hasher = new HashLinkConverter();
-    expect(hasher.convert(url)).toBe(expectedHash);
+  ])('%s', (_, url, expectedHashLink) => {
+    const hlc = new HashLinkConverter();
+    expect(hlc.convert(url)).toBe(expectedHashLink);
   });
 });
 
@@ -63,10 +63,15 @@ describe('Invalid embeds', () => {
       'https://www.yoütübe.com/watch?v=0EqSXDwTq6U',
       errors.invalidLink,
     ],
+    [
+      'Youtube link missing video id parameter',
+      'https://www.youtube.com/tZ_gn0E87Qo',
+      errors.invalidLink,
+    ],
   ])('%s', (_, url, expectedError) => {
-    const hasher = new HashLinkConverter();
+    const hlc = new HashLinkConverter();
     try {
-      hasher.convert(url);
+      hlc.convert(url);
       expect(true).toBe(false);
     } catch (error) {
       expect(error.message).toBe(expectedError);

--- a/assets/chat/js/hashlinkconverter.test.js
+++ b/assets/chat/js/hashlinkconverter.test.js
@@ -1,4 +1,10 @@
-import HashLinkConverter from './hashlinkconverter';
+import {
+  HashLinkConverter,
+  RUMBLE_EMBED_ERROR,
+  INVALID_LINK_ERROR,
+  MISSING_VIDEO_ID_ERROR,
+  MISSING_ARG_ERROR,
+} from './hashlinkconverter';
 
 describe('Valid embeds', () => {
   test.each([
@@ -44,37 +50,26 @@ describe('Valid embeds', () => {
   });
 });
 
-const errors = {
-  invalidLink: 'Invalid link',
-  badRumble:
-    'Rumble links have to be embed links - https://rumble.com/embed/<id>',
-};
-
 describe('Invalid embeds', () => {
   test.each([
-    ['Bad twitch link', 'witch.tv/xqc', errors.invalidLink],
+    ['Bad twitch link', 'witch.tv/xqc', INVALID_LINK_ERROR],
     [
       'Rumble non-embed link',
       'https://rumble.com/v29b9py-mirror-2023-02-13.html',
-      errors.badRumble,
-    ],
-    [
-      'Sussy fake youtube link',
-      'https://www.yoütübe.com/watch?v=0EqSXDwTq6U',
-      errors.invalidLink,
+      RUMBLE_EMBED_ERROR,
     ],
     [
       'Youtube link missing video id parameter',
       'https://www.youtube.com/tZ_gn0E87Qo',
-      errors.invalidLink,
+      MISSING_VIDEO_ID_ERROR,
+    ],
+    [
+      'No arguments were giving after the command',
+      undefined,
+      MISSING_ARG_ERROR,
     ],
   ])('%s', (_, url, expectedError) => {
     const hlc = new HashLinkConverter();
-    try {
-      hlc.convert(url);
-      expect(true).toBe(false);
-    } catch (error) {
-      expect(error.message).toBe(expectedError);
-    }
+    expect(() => hlc.convert(url)).toThrow(expectedError);
   });
 });

--- a/assets/chat/js/hashlinkconverter.test.js
+++ b/assets/chat/js/hashlinkconverter.test.js
@@ -1,0 +1,75 @@
+import HashLinkConverter from './hashlinkconverter';
+
+describe('Valid embeds', () => {
+  test.each([
+    ['Twitch stream', 'twitch.tv/xqc', '#twitch/xqc'],
+    [
+      'Twitch VoD',
+      'www.twitch.tv/videos/174256129?filter=archives&sort=views',
+      '#twitch-vod/174256129',
+    ],
+    [
+      'Twitch clip 1',
+      'https://www.twitch.tv/trainwreckstv/clip/ObeseFrigidBibimbapTBTacoLeft?filter=clips&range=all&sort=time',
+      '#twitch-clip/ObeseFrigidBibimbapTBTacoLeft',
+    ],
+    [
+      'Twitch clip 2',
+      'https://clips.twitch.tv/SingleHilariousRamenPunchTrees-NR0pJT1Lec5Q9E8p',
+      '#twitch-clip/SingleHilariousRamenPunchTrees-NR0pJT1Lec5Q9E8p',
+    ],
+    [
+      'Youtube video',
+      'https://www.youtube.com/watch?v=tZ_gn0E87Qo',
+      '#youtube/tZ_gn0E87Qo',
+    ],
+    [
+      'Youtube video shortened link',
+      'https://youtu.be/dPmLveKE_wY',
+      '#youtube/dPmLveKE_wY',
+    ],
+    [
+      'Youtube live stream shareable link',
+      'https://www.youtube.com/live/jfKfPfyJRdk?feature=share',
+      '#youtube/jfKfPfyJRdk',
+    ],
+    [
+      'Rumble embed',
+      'https://rumble.com/embed/v26pcdc/?pub=4',
+      '#rumble/v26pcdc',
+    ],
+  ])('%s', (_, url, expectedHash) => {
+    const hasher = new HashLinkConverter();
+    expect(hasher.convert(url)).toBe(expectedHash);
+  });
+});
+
+const errors = {
+  invalidLink: 'Invalid link',
+  badRumble:
+    'Rumble links have to be embed links - https://rumble.com/embed/<id>',
+};
+
+describe('Invalid embeds', () => {
+  test.each([
+    ['Bad twitch link', 'witch.tv/xqc', errors.invalidLink],
+    [
+      'Rumble non-embed link',
+      'https://rumble.com/v29b9py-mirror-2023-02-13.html',
+      errors.badRumble,
+    ],
+    [
+      'Sussy fake youtube link',
+      'https://www.yoütübe.com/watch?v=0EqSXDwTq6U',
+      errors.invalidLink,
+    ],
+  ])('%s', (_, url, expectedError) => {
+    const hasher = new HashLinkConverter();
+    try {
+      hasher.convert(url);
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error.message).toBe(expectedError);
+    }
+  });
+});


### PR DESCRIPTION
Added a HashLinkConverter class to handle converting URLs to an embed hash link.
Refactored `/embed` and `/postembed` commands to use this class. (#149)