### PR TITLE
Fix `/timestampformat` command

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -2005,17 +2005,15 @@ class Chat {
         )} (the default is 'HH:mm', for more info: http://momentjs.com/docs/#/displaying/format/)`
       ).into(this);
     } else {
-      const format = parts.slice(1, parts.length);
+      const format = parts.join(' ');
       if (!/^[a-z :.,-\\*]+$/i.test(format)) {
         MessageBuilder.error(
           'Invalid format, see: http://momentjs.com/docs/#/displaying/format/'
         ).into(this);
       } else {
-        MessageBuilder.info(
-          `New format: ${this.settings.get('timestampformat')}.`
-        ).into(this);
         this.settings.set('timestampformat', format);
         this.applySettings();
+        MessageBuilder.info(`New format: ${format}.`).into(this);
       }
     }
   }


### PR DESCRIPTION
Currently, the `/timestamp` can severely mess up a chatter's account settings and break chat for them. Using `/timestampformat HH mm` for example, removes 'HH' due to slicing the first word off and sets an array of  ['mm'] and breaks chat for them (haven't checked for the exact cause) and no longer see new messages (but can still send), and reloading chat shows nothing nor lets you send any messages afaik.