### PR TITLE
Fix on-stream chat text shadows

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -1691,7 +1691,10 @@ button.btn {
   .msg-chat {
     margin: 0;
     padding: 1px 20px 1px 5px;
-    filter: drop-shadow(1px 1px 1px black);
+    filter: drop-shadow(-0.5px -0.5px 0 rgba(black, 0.75))
+      drop-shadow(0.5px -0.5px 0 rgba(black, 0.75))
+      drop-shadow(-0.5px 0.5px 0 rgba(black, 0.75))
+      drop-shadow(0.5px 0.5px 0 rgba(black, 0.75));
     letter-spacing: 0.03em;
   }
 

--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -1691,10 +1691,10 @@ button.btn {
   .msg-chat {
     margin: 0;
     padding: 1px 20px 1px 5px;
-    filter: drop-shadow(-0.5px -0.5px 0 rgba(black, 0.75))
-      drop-shadow(0.5px -0.5px 0 rgba(black, 0.75))
-      drop-shadow(-0.5px 0.5px 0 rgba(black, 0.75))
-      drop-shadow(0.5px 0.5px 0 rgba(black, 0.75));
+    filter: drop-shadow(-1px -1px 0 rgba(black, 0.5))
+      drop-shadow(1px -1px 0 rgba(black, 0.5))
+      drop-shadow(-1px 1px 0 rgba(black, 0.5))
+      drop-shadow(1px 1px 0 rgba(black, 0.5));
     letter-spacing: 0.03em;
   }
 


### PR DESCRIPTION
<details>
  <summary>Current look</summary>

| Firefox  | Chrome |
| ------------- | ------------- |
| ![ksnip_20230224-183608](https://user-images.githubusercontent.com/41237021/221220715-6d3e3163-bd01-4549-8c57-edcb2148ed08.png) | ![ksnip_20230224-183621](https://user-images.githubusercontent.com/41237021/221220792-7d42b744-ad21-4f0b-b831-d2821009cd01.png) |

</details>

<details>
  <summary>Old look</summary>

| Firefox  | Chrome |
| ------------- | ------------- |
| ![ksnip_20230224-183711](https://user-images.githubusercontent.com/41237021/221220835-a259827a-2237-4e5c-8823-2a81cabcc4f9.png)  | ![ksnip_20230224-183718](https://user-images.githubusercontent.com/41237021/221220904-bce9e718-4398-47a1-88e7-3fc1e2ac53e7.png)  |

</details>

<details>
  <summary>With this change applied</summary>

| Firefox  | Chrome |
| ------------- | ------------- |
| ![ksnip_20230224-183802](https://user-images.githubusercontent.com/41237021/221220942-d5cf7f18-b773-4158-99c0-90e3530f5fc2.png) | ![ksnip_20230224-183808](https://user-images.githubusercontent.com/41237021/221220977-1f02ec79-1cf7-4902-ba6c-401f840a7475.png) |

</details>

Not exactly one-to-one, but fairly close.
Closes #165.
