### PR TITLE
Fix Firefox losing scroll position

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -698,9 +698,10 @@ class Chat {
 
     // Resize
     let resizing = false;
+    let wasPinned = true;
     const onresizecomplete = debounce(100, false, () => {
       resizing = false;
-      this.getActiveWindow().unlock();
+      this.getActiveWindow().update(wasPinned);
       this.focusIfNothingSelected();
     });
     const onresize = () => {
@@ -713,7 +714,7 @@ class Chat {
       if (!resizing) {
         resizing = true;
         ChatMenu.closeMenus(this);
-        this.getActiveWindow().lock();
+        wasPinned = this.getActiveWindow().waspinned;
       }
       onresizecomplete();
     };
@@ -775,7 +776,7 @@ class Chat {
     });
 
     this.loadingscrn.fadeOut(250, () => this.loadingscrn.remove());
-    this.mainwindow.updateAndPin();
+    this.mainwindow.update(true);
 
     this.setDefaultPlaceholderText();
     MessageBuilder.status(this.config.welcomeMessage).into(this);
@@ -883,7 +884,7 @@ class Chat {
       history.forEach((line) => this.source.parseAndDispatch({ data: line }));
       this.backlogloading = false;
       MessageBuilder.element('<hr/>').into(this);
-      this.mainwindow.updateAndPin();
+      this.mainwindow.update(true);
     }
     return this;
   }
@@ -996,7 +997,6 @@ class Chat {
 
     // eslint-disable-next-line no-param-reassign
     if (win === null) win = this.mainwindow;
-    win.lock();
 
     // Break the current combo if this message is not an emote
     // We don't need to check what type the current message is, we just know that its a new message, so the combo is invalid.
@@ -1072,7 +1072,7 @@ class Chat {
       );
     }
 
-    win.unlock();
+    win.update();
   }
 
   resolveMessage(nick, str) {
@@ -1089,24 +1089,20 @@ class Chat {
   }
 
   removeMessageByNick(nick) {
-    this.mainwindow.lock();
     this.mainwindow.removelines(
       `.msg-chat[data-username="${nick.toLowerCase()}"]`
     );
-    this.mainwindow.unlock();
+    this.mainwindow.update();
   }
 
   windowToFront(name) {
     const win = this.windows.get(name);
     if (win !== null && win !== this.getActiveWindow()) {
       this.windows.forEach((w) => {
-        if (w.visible) {
-          if (!w.locked()) w.lock();
-          w.hide();
-        }
+        if (w.visible) w.hide();
       });
       win.show();
-      if (win.locked()) win.unlock();
+      win.update();
       this.redrawWindowIndicators();
     }
 
@@ -1172,16 +1168,13 @@ class Chat {
         }
       });
     }
-    // null check on main window, since main window calls this during initialization
-    if (this.mainwindow !== null) this.mainwindow.lock();
 
     this.windowselect.toggle(this.windows.size > 1);
 
-    if (this.mainwindow !== null) this.mainwindow.unlock();
+    if (this.mainwindow !== null) this.mainwindow.update();
   }
 
   censor(nick) {
-    this.mainwindow.lock();
     const c = this.mainwindow.getlines(
       `.msg-chat[data-username="${nick.toLowerCase()}"]`
     );
@@ -1196,7 +1189,7 @@ class Chat {
       default:
         break;
     }
-    this.mainwindow.unlock();
+    this.mainwindow.update();
   }
 
   ignored(nick, text = null) {
@@ -1263,7 +1256,6 @@ class Chat {
 
     const maxHeightPixels = this.input.css('maxHeight');
     const maxHeight = parseInt(maxHeightPixels.slice(0, -2), 10);
-    const pinned = this.getActiveWindow().scrollplugin.isPinned();
 
     this.input.css('height', '');
     const calculatedHeight = this.input.prop('scrollHeight');
@@ -1275,7 +1267,7 @@ class Chat {
     );
 
     this.input.css('height', calculatedHeight);
-    this.getActiveWindow().updateAndPin(pinned);
+    this.getActiveWindow().update();
   }
 
   /**
@@ -1372,9 +1364,8 @@ class Chat {
       Chat.removeSlashCmdFromText(win.lastmessage.message) === textonly
     ) {
       if (win.lastmessage.type === MessageTypes.EMOTE) {
-        this.mainwindow.lock();
         win.lastmessage.incEmoteCount();
-        this.mainwindow.unlock();
+        this.mainwindow.update();
       } else {
         win.lastmessage.ui.remove();
         MessageBuilder.emote(textonly, data.timestamp, 2).into(this);

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -698,10 +698,8 @@ class Chat {
 
     // Resize
     let resizing = false;
-    let wasPinned = true;
     const onresizecomplete = debounce(100, false, () => {
       resizing = false;
-      this.getActiveWindow().update(wasPinned);
       this.focusIfNothingSelected();
     });
     const onresize = () => {
@@ -714,7 +712,6 @@ class Chat {
       if (!resizing) {
         resizing = true;
         ChatMenu.closeMenus(this);
-        wasPinned = this.getActiveWindow().waspinned;
       }
       onresizecomplete();
     };

--- a/assets/chat/js/messages/PinnedMessage.js
+++ b/assets/chat/js/messages/PinnedMessage.js
@@ -75,12 +75,11 @@ export default class PinnedMessage extends ChatUserMessage {
    * @returns {PinnedMessage} Pinned message.
    */
   pin(chat = null, visibility = true) {
-    chat.mainwindow.lock();
     this.ui.id = 'msg-pinned';
     this.ui.classList.toggle('msg-pinned', true);
     this.visible = visibility;
     this.ui.querySelector('span.features').classList.toggle('hidden', true);
-    chat.mainwindow.unlock();
+    chat.mainwindow.update();
 
     if (chat.user.hasModPowers()) {
       const unpinMessage = document.createElement('a');

--- a/assets/chat/js/poll.js
+++ b/assets/chat/js/poll.js
@@ -89,18 +89,16 @@ class ChatPoll {
   hide() {
     if (!this.hidden) {
       this.hidden = true;
-      this.chat.mainwindow.lock();
       this.ui.removeClass('active');
-      this.chat.mainwindow.unlock();
+      this.chat.mainwindow.update();
     }
   }
 
   show() {
     if (this.hidden) {
       this.hidden = false;
-      this.chat.mainwindow.lock();
       this.ui.addClass('active');
-      this.chat.mainwindow.unlock();
+      this.chat.mainwindow.update();
     }
   }
 

--- a/assets/chat/js/window.js
+++ b/assets/chat/js/window.js
@@ -22,7 +22,6 @@ class ChatWindow extends EventEmitter {
     this.maxlines = 0;
     this.linecount = 0;
     this.locks = 0;
-    this.waspinned = true;
     this.scrollplugin = null;
     this.visible = false;
     this.tag = null;
@@ -47,8 +46,7 @@ class ChatWindow extends EventEmitter {
     this.maxlines = chat.settings.get('maxlines');
     this.scrollplugin = new ChatScrollPlugin(
       this.lines,
-      this.lines.parentElement,
-      this
+      this.lines.parentElement
     );
     this.tag =
       chat.taggednicks.get(normalized) ||
@@ -96,13 +94,13 @@ class ChatWindow extends EventEmitter {
   }
 
   update(forcePin) {
-    if (this.waspinned || forcePin) this.scrollplugin.scrollBottom();
+    this.scrollplugin.update(forcePin);
   }
 
   // Rid excess chat lines if the chat is pinned
   // Get the scroll position before adding the new line / removing old lines
   cleanup() {
-    if (this.scrollplugin.pinned || this.waspinned) {
+    if (this.scrollplugin.wasPinned) {
       const lines = [...this.lines.children];
       if (lines.length >= this.maxlines) {
         const remove = lines.slice(0, lines.length - this.maxlines);

--- a/assets/chat/js/window.js
+++ b/assets/chat/js/window.js
@@ -47,7 +47,8 @@ class ChatWindow extends EventEmitter {
     this.maxlines = chat.settings.get('maxlines');
     this.scrollplugin = new ChatScrollPlugin(
       this.lines,
-      this.lines.parentElement
+      this.lines.parentElement,
+      this
     );
     this.tag =
       chat.taggednicks.get(normalized) ||
@@ -94,28 +95,14 @@ class ChatWindow extends EventEmitter {
     });
   }
 
-  locked() {
-    return this.locks > 0;
-  }
-
-  lock() {
-    this.locks += 1;
-    if (this.locks === 1) {
-      this.waspinned = this.scrollplugin.isPinned();
-    }
-  }
-
-  unlock() {
-    this.locks -= 1;
-    if (this.locks === 0) {
-      this.scrollplugin.updateAndPin(this.waspinned);
-    }
+  update(forcePin) {
+    if (this.waspinned || forcePin) this.scrollplugin.scrollBottom();
   }
 
   // Rid excess chat lines if the chat is pinned
   // Get the scroll position before adding the new line / removing old lines
   cleanup() {
-    if (this.scrollplugin.isPinned() || this.waspinned) {
+    if (this.scrollplugin.pinned || this.waspinned) {
       const lines = [...this.lines.children];
       if (lines.length >= this.maxlines) {
         const remove = lines.slice(0, lines.length - this.maxlines);
@@ -128,10 +115,6 @@ class ChatWindow extends EventEmitter {
   }
 
   cleanupThrottle = throttle(50, this.cleanup);
-
-  updateAndPin(pin = true) {
-    this.scrollplugin.updateAndPin(pin);
-  }
 }
 
 export default ChatWindow;


### PR DESCRIPTION
The "lock" system that's used right now was used to avoid excessive nanoscroller updates by limiting the amount of calls, but since OverlayScrollbars updates the scrollbar automatically it's not really needed.

Making this a draft PR since:
1. I might be overthinking this and there's a way easier solution
2. This needs more testing, since it can cause regressions (I did test a bit and ran into Chrome losing scroll position if you resize the window _too_ much)

For some reason Firefox:
1. Resizes the page/window slightly when you open the new tab
2. Refuses to stick to the bottom of chat on resizes (perhaps the 'resize' event fires too late to catch the right scroll position?)

Those 2 reasons might be the reason it loses the scroll position sometimes.
Closes #171.