### PR TITLE
Automatically shorten long links

### DIFF
--- a/assets/chat/js/formatters/UrlFormatter.js
+++ b/assets/chat/js/formatters/UrlFormatter.js
@@ -73,7 +73,7 @@ export default class UrlFormatter {
         const encodedUrl = self.encodeUrl(m[0]);
         const maxUrlLength = 90;
         let urlText = encodedUrl;
-        if (encodedUrl.length > maxUrlLength) {
+        if (urlText.length > maxUrlLength) {
           const middleIndex = Math.floor(maxUrlLength / 2);
           urlText = `${encodedUrl.slice(
             0,

--- a/assets/chat/js/formatters/UrlFormatter.js
+++ b/assets/chat/js/formatters/UrlFormatter.js
@@ -75,9 +75,11 @@ export default class UrlFormatter {
         let urlText = encodedUrl;
         if (encodedUrl.length > maxUrlLength) {
           const middleIndex = Math.floor(maxUrlLength / 2);
-          const start = encodedUrl.slice(0, middleIndex);
-          const end = encodedUrl.slice(-middleIndex - 10);
-          urlText = `${start}...${end}`;
+          urlText = `${encodedUrl.slice(
+            0,
+            middleIndex - 3
+          )}...${encodedUrl.slice(middleIndex + 4 - (encodedUrl.length % 2))}`;
+          urlText = `${urlText.slice(0, 40)}...${urlText.slice(-40)}`;
         }
         const extra = self.encodeUrl(decodedUrl.substring(m[0].length));
         const href = `${scheme ? '' : 'http://'}${encodedUrl}`;

--- a/assets/chat/js/formatters/UrlFormatter.js
+++ b/assets/chat/js/formatters/UrlFormatter.js
@@ -74,11 +74,6 @@ export default class UrlFormatter {
         const maxUrlLength = 90;
         let urlText = encodedUrl;
         if (urlText.length > maxUrlLength) {
-          const middleIndex = Math.floor(maxUrlLength / 2);
-          urlText = `${encodedUrl.slice(
-            0,
-            middleIndex - 3
-          )}...${encodedUrl.slice(middleIndex + 4 - (encodedUrl.length % 2))}`;
           urlText = `${urlText.slice(0, 40)}...${urlText.slice(-40)}`;
         }
         const extra = self.encodeUrl(decodedUrl.substring(m[0].length));

--- a/assets/chat/js/formatters/UrlFormatter.js
+++ b/assets/chat/js/formatters/UrlFormatter.js
@@ -71,9 +71,17 @@ export default class UrlFormatter {
       const m = decodedUrl.match(self.linkregex);
       if (m) {
         const encodedUrl = self.encodeUrl(m[0]);
+        const maxUrlLength = 90;
+        let urlText = encodedUrl;
+        if (encodedUrl.length > maxUrlLength) {
+          const middleIndex = Math.floor(maxUrlLength / 2);
+          const start = encodedUrl.slice(0, middleIndex);
+          const end = encodedUrl.slice(-middleIndex - 10);
+          urlText = `${start}...${end}`;
+        }
         const extra = self.encodeUrl(decodedUrl.substring(m[0].length));
         const href = `${scheme ? '' : 'http://'}${encodedUrl}`;
-        return `<a target="_blank" class="externallink ${extraclass}" href="${href}" rel="nofollow">${encodedUrl}</a>${extra}`;
+        return `<a target="_blank" class="externallink ${extraclass}" href="${href}" rel="nofollow">${urlText}</a>${extra}`;
       }
       return url;
     });


### PR DESCRIPTION
Continuing the work started in https://github.com/destinygg/chat-gui/pull/117 shortens links over 90 characters to 80 characters with an elipsis.

![image](https://user-images.githubusercontent.com/1808209/224336241-1667ddd4-6e9a-418b-9372-07826bcf815e.png)


resolves #113