### PR TITLE
Keep pinned messages opaque during focus

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -639,6 +639,10 @@ hr {
 /* Focus or highlight a line */
 .focus .msg-chat {
   opacity: 0.3;
+
+  &.msg-pinned {
+    opacity: 1;
+  }
 }
 
 /* Emotes and combo */


### PR DESCRIPTION
If the issue #195 is unintended this will keep pinned messages opaque when chatters are focused.

![image](https://user-images.githubusercontent.com/1808209/226428781-1cdc62b8-165c-4b3f-ab3e-4ec26dc17cd7.png)

resolves #195