### PR TITLE
fix: pins auto-dismissing on chat reconnect

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1348,12 +1348,10 @@ class Chat {
   }
 
   onPIN(msg) {
-    if (!msg.data) {
-      this.pinnedMessage?.unpin();
-      return;
-    }
-
+    if (this.pinnedMessage?.uuid === msg.uuid) return;
     this.pinnedMessage?.unpin();
+    if (!msg.data) return;
+
     const usr = this.users.get(msg.nick.toLowerCase()) ?? new ChatUser(msg);
     this.pinnedMessage = MessageBuilder.pinned(
       msg.data,


### PR DESCRIPTION
On chat reconnect, if the pin existed already it would dismiss it automatically, even if it didn't change. Now, if the pin already exists and the UUID matches, we just ignore the event.