### PR TITLE
fix mid sentence autocomplete

### DIFF
--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -130,7 +130,7 @@ class ChatAutoComplete {
       } else if (char.length > 0) {
         this.promoteIfSelected();
         const str = this.input.val().toString();
-        const offset = this.input[0].selectionStart + 1;
+        const offset = this.input[0].selectionStart;
         const pre = str.substring(0, offset);
         const post = str.substring(offset);
         const criteria = buildSearchCriteria(pre + char + post, offset);

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -133,7 +133,7 @@ class ChatAutoComplete {
         const offset = this.input[0].selectionStart;
         const pre = str.substring(0, offset);
         const post = str.substring(offset);
-        const criteria = buildSearchCriteria(pre + char + post, offset);
+        const criteria = buildSearchCriteria(pre + char + post, offset + 1);
         this.search(criteria);
         // If the first result is exact, highlight it.
         if (this.results.length > 0 && this.results[0].data === criteria.word) {


### PR DESCRIPTION
Resolves mid sentence autocomplete by trimming whitespace from the pre and post string slices in the input event handler, and then depending on any trailing whitespace we determine whether we are mid sentence and slightly reformat the search string. 

might not be the most elegant solution so open to plenty of feedback 😄 

![autocomplete](https://user-images.githubusercontent.com/1808209/230791297-2a0881ea-fa49-4c18-b13c-729bb44b648a.gif)


resolves #210 