### PR TITLE
chat-gui-112: Enhance message user info window

### DIFF
--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -287,6 +287,12 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
   }
 
   updateContent(e) {
+    const chatMenuIsOpen = this.chat.menus
+      .get('user-info')
+      .ui[0].className.includes('active');
+
+    if (!chatMenuIsOpen) return;
+
     if (this.messageArray.length > 0 && this.messagesList) {
       const newMessagesSet = this.chat.output.find(
         `[data-username='${this.clickedNick}']`
@@ -358,10 +364,10 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
         const bTimestamp = $(b)
           .find('[data-unixtimestamp]')
           .data('unixtimestamp');
-        return bTimestamp - aTimestamp;
+        return aTimestamp - bTimestamp;
       });
       sortedMessageArray.toArray().forEach((element) => {
-        const text = element.innerText.split(':')[1];
+        const text = element.getElementsByClassName('text')[0].innerText;
         const msg = MessageBuilder.message(
           text,
           new ChatUser(this.clickedNick)


### PR DESCRIPTION
Addresses issue 112: https://github.com/destinygg/chat-gui/issues/112

When users right click on a username from the chat window, we now parse out all messages that are authored by selected username and display as a message history in the user info menu. As long as the user info menu remains open, an event listener will dynamically update the message history based on the chat ui. Older messages will disappear from the selected user message history as they disappear from chat and new messages will render as they're added to the chat.

https://user-images.githubusercontent.com/45981290/231689044-e99b826c-4b36-4655-adef-ca0a67bf8b15.mp4






