### PR TITLE
chat-gui-112: Enhance message user info window 

### DIFF
--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -287,6 +287,12 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
   }
 
   updateContent(e) {
+    const chatMenuIsOpen = this.chat.menus
+      .get('user-info')
+      .ui[0].className.includes('active');
+
+    if (!chatMenuIsOpen) return;
+
     if (this.messageArray.length > 0 && this.messagesList) {
       const newMessagesSet = this.chat.output.find(
         `[data-username='${this.clickedNick}']`
@@ -358,10 +364,10 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
         const bTimestamp = $(b)
           .find('[data-unixtimestamp]')
           .data('unixtimestamp');
-        return bTimestamp - aTimestamp;
+        return aTimestamp - bTimestamp;
       });
       sortedMessageArray.toArray().forEach((element) => {
-        const text = element.innerText.split(':')[1];
+        const text = element.getElementsByClassName('text')[0].innerText;
         const msg = MessageBuilder.message(
           text,
           new ChatUser(this.clickedNick)

--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -49,6 +49,10 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     this.chat.output.on('mouseup', '.msg-user .user', (e) => {
       e.stopPropagation();
     });
+
+    this.chat.output.on('DOMSubtreeModified', (e) => {
+      this.updateContent(e);
+    });
   }
 
   showUser(e, user, userlist = false) {
@@ -218,7 +222,9 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
   }
 
   addContent(message, userlist) {
-    this.messageArray = userlist ? [] : [message];
+    this.messageArray = userlist
+      ? []
+      : this.chat.output.find(`[data-username='${this.clickedNick}']`);
 
     const prettyNick = message.find('.user')[0].innerText;
     const nick = message.data('username');
@@ -280,6 +286,40 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     this.redraw();
   }
 
+  updateContent(e) {
+    if (this.messageArray.length > 0 && this.messagesList) {
+      const newMessagesSet = this.chat.output.find(
+        `[data-username='${this.clickedNick}']`
+      );
+      const isNewFirstMessage =
+        this.messageArray
+          .first()
+          .find('[data-unixtimestamp]')
+          .data('unixtimestamp') <
+        newMessagesSet
+          .first()
+          .find('[data-unixtimestamp]')
+          .data('unixtimestamp');
+
+      const isNewLastMessage =
+        e.target &&
+        e.target.lastChild &&
+        e.target.lastChild.nodeType === Node.ELEMENT_NODE
+          ? e.target.lastChild.getAttribute('data-username') ===
+            this.clickedNick
+          : false;
+
+      if (isNewFirstMessage || isNewLastMessage) {
+        this.messageArray = newMessagesSet;
+        const messageList = this.createMessages(false);
+        this.messagesContainer.empty();
+        messageList.forEach((element) => {
+          this.messagesContainer.append(element);
+        });
+      }
+    }
+  }
+
   buildCreatedDate(nick) {
     const user = this.chat.users.get(nick.toLowerCase());
     if (user.createdDate === '') {
@@ -311,15 +351,21 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
   createMessages(userlist) {
     const displayedMessages = [];
     if (this.messageArray.length > 0) {
-      let nextMsg = this.messageArray[0].next('.msg-continue');
-      while (nextMsg.length > 0) {
-        this.messageArray.push(nextMsg);
-        nextMsg = nextMsg.next('.msg-continue');
-      }
-      this.messageArray.forEach((element) => {
-        const text = element.find('.text')[0].innerText;
-        const nick = element.data('username');
-        const msg = MessageBuilder.message(text, new ChatUser(nick));
+      const sortedMessageArray = this.messageArray.sort((a, b) => {
+        const aTimestamp = $(a)
+          .find('[data-unixtimestamp]')
+          .data('unixtimestamp');
+        const bTimestamp = $(b)
+          .find('[data-unixtimestamp]')
+          .data('unixtimestamp');
+        return bTimestamp - aTimestamp;
+      });
+      sortedMessageArray.toArray().forEach((element) => {
+        const text = element.innerText.split(':')[1];
+        const msg = MessageBuilder.message(
+          text,
+          new ChatUser(this.clickedNick)
+        );
         displayedMessages.push(msg.html(this.chat));
       });
     } else if (!userlist) {


### PR DESCRIPTION
Addresses issue 112: https://github.com/destinygg/chat-gui/issues/112

When users right click on a username from the chat window, we now parse out all messages that are authored by selected username and display as a message history in the user info menu. As long as the user info menu remains open, an event listener will dynamically update the message history based on the chat ui. Older messages will disappear from the selected user message history as they disappear from chat and new messages will render as they're added to the chat.


https://user-images.githubusercontent.com/45981290/231695739-65e0c0de-5671-47d2-84cf-fa878054a708.mp4

