### PR TITLE
Allow auto completing in the middle of a message

### DIFF
--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -130,10 +130,10 @@ class ChatAutoComplete {
       } else if (char.length > 0) {
         this.promoteIfSelected();
         const str = this.input.val().toString();
-        const offset = this.input[0].selectionStart + 1;
+        const offset = this.input[0].selectionStart;
         const pre = str.substring(0, offset);
         const post = str.substring(offset);
-        const criteria = buildSearchCriteria(pre + char + post, offset);
+        const criteria = buildSearchCriteria(pre + char + post, offset + 1);
         this.search(criteria);
         // If the first result is exact, highlight it.
         if (this.results.length > 0 && this.results[0].data === criteria.word) {


### PR DESCRIPTION
Attempt to fix the behavior in #210 

If clicking in the middle of a word, tab will replace the text after it. Unsure if that is the behavior described here: https://github.com/destinygg/chat-gui/pull/214#issuecomment-1509320211