### PR TITLE
Refactor const usage in chat.js

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1453,7 +1453,7 @@ class Chat {
   }
 
   cmdHINT(parts) {
-    const arr = [...hintstrings];
+    const arr = [...new Map(Object.entries(hintstrings))];
     const i = parts && parts[0] ? parseInt(parts[0], 10) - 1 : -1;
     if (i > 0 && i < Object.keys(hintstrings).length) {
       MessageBuilder.info(arr[i][1]).into(this);

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -87,7 +87,7 @@ class Chat {
     this.users = new Map();
     this.whispers = new Map();
     this.windows = new Map();
-    this.settings = new Map(Object.entries(settingsdefault));
+    this.settings = new Map(settingsdefault);
     this.commands = new ChatCommands();
     this.autocomplete = new ChatAutoComplete();
     this.menus = new Map();
@@ -231,7 +231,7 @@ class Chat {
     const oldversion = stored.has('schemaversion')
       ? parseInt(stored.get('schemaversion'), 10)
       : -1;
-    const newversion = settingsdefault.schemaversion;
+    const newversion = settingsdefault.get('schemaversion');
     if (oldversion !== -1 && newversion > oldversion) {
       Settings.upgrade(this, oldversion, newversion);
       this.settings.set('schemaversion', newversion);
@@ -1017,9 +1017,7 @@ class Chat {
       } users.`
     ).into(this);
     if (this.showmotd) {
-      this.cmdHINT([
-        Math.floor(Math.random() * Object.keys(hintstrings).length),
-      ]);
+      this.cmdHINT([Math.floor(Math.random() * hintstrings.size)]);
       this.showmotd = false;
     }
   }
@@ -1190,7 +1188,7 @@ class Chat {
         );
         break;
       default:
-        message = MessageBuilder.error(errorstrings[desc] || desc);
+        message = MessageBuilder.error(errorstrings.get(desc) || desc);
     }
 
     message.into(this, this.getActiveWindow());
@@ -1450,9 +1448,9 @@ class Chat {
   }
 
   cmdHINT(parts) {
-    const arr = [...new Map(Object.entries(hintstrings))];
+    const arr = [...hintstrings];
     const i = parts && parts[0] ? parseInt(parts[0], 10) - 1 : -1;
-    if (i > 0 && i < Object.keys(hintstrings).length) {
+    if (i > 0 && i < hintstrings.size) {
       MessageBuilder.info(arr[i][1]).into(this);
     } else {
       if (
@@ -2116,7 +2114,7 @@ class Chat {
     let url = parts[0];
 
     if (!this.user.hasAnyFeatures(UserFeatures.ADMIN, UserFeatures.MODERATOR)) {
-      MessageBuilder.error(errorstrings.nopermission).into(this);
+      MessageBuilder.error(errorstrings.get('nopermission')).into(this);
       return;
     }
 
@@ -2158,7 +2156,7 @@ class Chat {
 
   cmdUNHOST() {
     if (!this.user.hasAnyFeatures(UserFeatures.ADMIN, UserFeatures.MODERATOR)) {
-      MessageBuilder.error(errorstrings.nopermission).into(this);
+      MessageBuilder.error(errorstrings.get('nopermission')).into(this);
       return;
     }
 

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -890,7 +890,6 @@ class Chat {
         (this.settings.get('ignorementions') &&
           this.ignoreregex &&
           this.ignoreregex.test(text)) ||
-        (this.settings.get('hidensfw') && this.settings.get('hidensfl')) ||
         (this.settings.get('hidensfl') && nsflregex.test(text)) ||
         (this.settings.get('hidensfw') && nsfwregex.test(text))
       );
@@ -1191,9 +1190,7 @@ class Chat {
         );
         break;
       default:
-        message = MessageBuilder.error(
-          errorstrings[desc.replace(/'/g, '')] || desc
-        );
+        message = MessageBuilder.error(errorstrings[desc] || desc);
     }
 
     message.into(this, this.getActiveWindow());

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -87,7 +87,7 @@ class Chat {
     this.users = new Map();
     this.whispers = new Map();
     this.windows = new Map();
-    this.settings = Object.entries(settingsdefault);
+    this.settings = new Map(Object.entries(settingsdefault));
     this.commands = new ChatCommands();
     this.autocomplete = new ChatAutoComplete();
     this.menus = new Map();

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -40,6 +40,91 @@ const KEYCODES = {
   F12: 123,
 };
 
+const tagcolors = [
+  'green',
+  'yellow',
+  'orange',
+  'red',
+  'purple',
+  'blue',
+  'sky',
+  'lime',
+  'pink',
+  'black',
+];
+
+const errorstrings = {
+  unknown: 'Unknown error, this usually indicates an internal problem :(',
+  nopermission: 'You do not have the required permissions to use that',
+  protocolerror: 'Invalid or badly formatted',
+  needlogin: 'You have to be logged in to use that',
+  msgempty: 'Message cannot be empty',
+  msgtoolong: 'Message cannot be longer than 512 characters',
+  invalidmsg: 'The message was invalid',
+  throttled: 'Throttled! You were trying to send messages too fast',
+  duplicate: 'The message is identical to the last one you sent',
+  submode: 'The channel is currently in subscriber only mode',
+  needbanreason: 'Providing a reason for the ban is mandatory',
+  privmsgbanned: 'Cannot send private messages while banned',
+  requiresocket: 'This chat requires WebSockets',
+  toomanyconnections: 'Only 5 concurrent connections allowed',
+  socketerror: 'Error contacting server',
+  privmsgaccounttooyoung: 'Your account is too recent to send private messages',
+  notfound: 'The user was not found',
+  notconnected: 'You have to be connected to use that',
+  activepoll: 'Poll already started.',
+  noactivepoll: 'No poll started.',
+  alreadyvoted: 'You have already voted!',
+};
+
+const hintstrings = {
+  slashhelp:
+    'Type in /help for a list of more commands that do advanced things, like modify your scroll-back size.',
+  tabcompletion:
+    'Use the tab key to auto-complete names and emotes (for user only completion prepend a @ or hold shift).',
+  hoveremotes:
+    'Hovering your cursor over an emote will show you the emote code.',
+  highlight: 'Chat messages containing your username will be highlighted.',
+  notify: 'Use /msg <nick> to send a private message to someone.',
+  ignoreuser:
+    'Use /ignore <nick> to hide messages from pesky chatters. You can even ignore multiple users at once - /ignore <nick_1> ... <nick_n>!',
+  mutespermanent: "Mutes are never persistent, don't worry it will pass!",
+  tagshint: `Use the /tag <nick> [<color> <note>] to tag users you like. There are preset colors to choose from ${tagcolors.join(
+    ', '
+  )}.`,
+  bigscreen: `Bigscreen! Did you know you can have the chat on the left or right side of the stream by clicking the swap icon in the top left?`,
+  danisold:
+    'Destiny is an Amazon Associate. He earns a commission on qualifying purchases of any product on Amazon linked in Destiny.gg chat.',
+};
+
+const settingsdefault = {
+  schemaversion: 2,
+  showtime: false,
+  hideflairicons: false,
+  profilesettings: false,
+  timestampformat: 'HH:mm',
+  maxlines: 250,
+  notificationwhisper: false,
+  notificationhighlight: false,
+  highlight: true, // todo rename this to `highlightself` or something
+  customhighlight: [],
+  highlightnicks: [],
+  taggednicks: [],
+  taggednotes: [],
+  showremoved: 0, // 0 = false (removes), 1 = true (censor), 2 = do nothing
+  showhispersinchat: false,
+  ignorenicks: [],
+  focusmentioned: false,
+  notificationtimeout: true,
+  ignorementions: false,
+  autocompletehelper: true,
+  taggedvisibility: false,
+  hidensfw: false,
+  hidensfl: false,
+  fontscale: 'auto',
+  censorbadwords: false,
+};
+
 function getKeyCode(e) {
   return e.which || e.keyCode || -1;
 }
@@ -48,4 +133,13 @@ function isKeyCode(e, code) {
   return getKeyCode(e) === code;
 }
 
-export { KEYCODES, DATE_FORMATS, isKeyCode, getKeyCode };
+export {
+  KEYCODES,
+  DATE_FORMATS,
+  isKeyCode,
+  getKeyCode,
+  tagcolors,
+  errorstrings,
+  hintstrings,
+  settingsdefault,
+};

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -53,77 +53,84 @@ const tagcolors = [
   'black',
 ];
 
-const errorstrings = {
-  unknown: 'Unknown error, this usually indicates an internal problem :(',
-  nopermission: 'You do not have the required permissions to use that',
-  protocolerror: 'Invalid or badly formatted',
-  needlogin: 'You have to be logged in to use that',
-  msgempty: 'Message cannot be empty',
-  msgtoolong: 'Message cannot be longer than 512 characters',
-  invalidmsg: 'The message was invalid',
-  throttled: 'Throttled! You were trying to send messages too fast',
-  duplicate: 'The message is identical to the last one you sent',
-  submode: 'The channel is currently in subscriber only mode',
-  needbanreason: 'Providing a reason for the ban is mandatory',
-  privmsgbanned: 'Cannot send private messages while banned',
-  requiresocket: 'This chat requires WebSockets',
-  toomanyconnections: 'Only 5 concurrent connections allowed',
-  socketerror: 'Error contacting server',
-  privmsgaccounttooyoung: 'Your account is too recent to send private messages',
-  notfound: 'The user was not found',
-  notconnected: 'You have to be connected to use that',
-  activepoll: 'Poll already started.',
-  noactivepoll: 'No poll started.',
-  alreadyvoted: 'You have already voted!',
-};
+const errorstrings = new Map(
+  Object.entries({
+    unknown: 'Unknown error, this usually indicates an internal problem :(',
+    nopermission: 'You do not have the required permissions to use that',
+    protocolerror: 'Invalid or badly formatted',
+    needlogin: 'You have to be logged in to use that',
+    msgempty: 'Message cannot be empty',
+    msgtoolong: 'Message cannot be longer than 512 characters',
+    invalidmsg: 'The message was invalid',
+    throttled: 'Throttled! You were trying to send messages too fast',
+    duplicate: 'The message is identical to the last one you sent',
+    submode: 'The channel is currently in subscriber only mode',
+    needbanreason: 'Providing a reason for the ban is mandatory',
+    privmsgbanned: 'Cannot send private messages while banned',
+    requiresocket: 'This chat requires WebSockets',
+    toomanyconnections: 'Only 5 concurrent connections allowed',
+    socketerror: 'Error contacting server',
+    privmsgaccounttooyoung:
+      'Your account is too recent to send private messages',
+    notfound: 'The user was not found',
+    notconnected: 'You have to be connected to use that',
+    activepoll: 'Poll already started.',
+    noactivepoll: 'No poll started.',
+    alreadyvoted: 'You have already voted!',
+  })
+);
 
-const hintstrings = {
-  slashhelp:
-    'Type in /help for a list of more commands that do advanced things, like modify your scroll-back size.',
-  tabcompletion:
-    'Use the tab key to auto-complete names and emotes (for user only completion prepend a @ or hold shift).',
-  hoveremotes:
-    'Hovering your cursor over an emote will show you the emote code.',
-  highlight: 'Chat messages containing your username will be highlighted.',
-  notify: 'Use /msg <nick> to send a private message to someone.',
-  ignoreuser:
-    'Use /ignore <nick> to hide messages from pesky chatters. You can even ignore multiple users at once - /ignore <nick_1> ... <nick_n>!',
-  mutespermanent: "Mutes are never persistent, don't worry it will pass!",
-  tagshint: `Use the /tag <nick> [<color> <note>] to tag users you like. There are preset colors to choose from ${tagcolors.join(
-    ', '
-  )}.`,
-  bigscreen: `Bigscreen! Did you know you can have the chat on the left or right side of the stream by clicking the swap icon in the top left?`,
-  danisold:
-    'Destiny is an Amazon Associate. He earns a commission on qualifying purchases of any product on Amazon linked in Destiny.gg chat.',
-};
+const hintstrings = new Map(
+  Object.entries({
+    slashhelp:
+      'Type in /help for a list of more commands that do advanced things, like modify your scroll-back size.',
+    tabcompletion:
+      'Use the tab key to auto-complete names and emotes (for user only completion prepend a @ or hold shift).',
+    hoveremotes:
+      'Hovering your cursor over an emote will show you the emote code.',
+    highlight: 'Chat messages containing your username will be highlighted.',
+    notify: 'Use /msg <nick> to send a private message to someone.',
+    ignoreuser:
+      'Use /ignore <nick> to hide messages from pesky chatters. You can even ignore multiple users at once - /ignore <nick_1> ... <nick_n>!',
+    mutespermanent: "Mutes are never persistent, don't worry it will pass!",
+    tagshint: `Use the /tag <nick> [<color> <note>] to tag users you like. There are preset colors to choose from ${tagcolors.join(
+      ', '
+    )}.`,
+    bigscreen: `Bigscreen! Did you know you can have the chat on the left or right side of the stream by clicking the swap icon in the top left?`,
+    danisold:
+      'Destiny is an Amazon Associate. He earns a commission on qualifying purchases of any product on Amazon linked in Destiny.gg chat.',
+  })
+);
 
-const settingsdefault = {
-  schemaversion: 2,
-  showtime: false,
-  hideflairicons: false,
-  profilesettings: false,
-  timestampformat: 'HH:mm',
-  maxlines: 250,
-  notificationwhisper: false,
-  notificationhighlight: false,
-  highlight: true, // todo rename this to `highlightself` or something
-  customhighlight: [],
-  highlightnicks: [],
-  taggednicks: [],
-  taggednotes: [],
-  showremoved: 0, // 0 = false (removes), 1 = true (censor), 2 = do nothing
-  showhispersinchat: false,
-  ignorenicks: [],
-  focusmentioned: false,
-  notificationtimeout: true,
-  ignorementions: false,
-  autocompletehelper: true,
-  taggedvisibility: false,
-  hidensfw: false,
-  hidensfl: false,
-  fontscale: 'auto',
-  censorbadwords: false,
-};
+const settingsdefault = new Map(
+  Object.entries({
+    schemaversion: 2,
+    showtime: false,
+    hideflairicons: false,
+    profilesettings: false,
+    timestampformat: 'HH:mm',
+    maxlines: 250,
+    notificationwhisper: false,
+    notificationhighlight: false,
+    highlight: true, // todo rename this to `highlightself` or something
+    customhighlight: [],
+    highlightnicks: [],
+    taggednicks: [],
+    taggednotes: [],
+    showremoved: 0, // 0 = false (removes), 1 = true (censor), 2 = do nothing
+    showhispersinchat: false,
+    ignorenicks: [],
+    focusmentioned: false,
+    notificationtimeout: true,
+    ignorementions: false,
+    autocompletehelper: true,
+    taggedvisibility: false,
+    hidensfw: false,
+    hidensfl: false,
+    fontscale: 'auto',
+    censorbadwords: false,
+  })
+);
 
 function getKeyCode(e) {
   return e.which || e.keyCode || -1;

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -123,9 +123,6 @@ const settingsdefault = {
   hidensfl: false,
   fontscale: 'auto',
   censorbadwords: false,
-  get(key) {
-    return this[key];
-  },
 };
 
 function getKeyCode(e) {

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -123,6 +123,9 @@ const settingsdefault = {
   hidensfl: false,
   fontscale: 'auto',
   censorbadwords: false,
+  get(key) {
+    return this[key];
+  },
 };
 
 function getKeyCode(e) {

--- a/assets/chat/js/regex.js
+++ b/assets/chat/js/regex.js
@@ -2,8 +2,8 @@ const regexslashcmd = /^\/([a-z0-9]+)[\s]?/i;
 const regextime = /(\d+)([a-z]+)?/gi;
 const nickmessageregex = /(?=@?)(\w{3,20})/g;
 const nickregex = /^\w{3,20}$/;
-const nsfwregex = /\b(?:NSFW)\b/i;
-const nsflregex = /\b(?:NSFL)\b/i;
+const nsfwregex = /\bNSFW\b/i;
+const nsflregex = /\bNSFL\b/i;
 
 export {
   regexslashcmd,

--- a/assets/chat/js/regex.js
+++ b/assets/chat/js/regex.js
@@ -1,3 +1,19 @@
+const regexslashcmd = /^\/([a-z0-9]+)[\s]?/i;
+const regextime = /(\d+)([a-z]+)?/gi;
+const nickmessageregex = /(?=@?)(\w{3,20})/g;
+const nickregex = /^\w{3,20}$/;
+const nsfwregex = /\b(?:NSFW)\b/i;
+const nsflregex = /\b(?:NSFL)\b/i;
+
+export {
+  regexslashcmd,
+  regextime,
+  nickmessageregex,
+  nickregex,
+  nsfwregex,
+  nsflregex,
+};
+
 export default function makeSafeForRegex(str) {
   return str.trim().replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
 }


### PR DESCRIPTION
Builds on the PR #211 and addresses the comments from @11k 

Moves tagcolors, errorstrings, hintstrings and settingsdefault maps into const.js

Refactors errorstrings, hintstrings and settingsdefault into objects.

Moves regexslashcmd, regextime, nickmessageregex, nickregex, nsfwregex, nsflregex into regex.js

Removes nsfwnsflregex

Minor logic adjustments to do with the refactors

resolves #247