### PR TITLE
Restore original load settings behavior

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -325,7 +325,7 @@ class Chat {
     // If authed and #settings.profilesettings=true use #settings
     // Else use whats in LocalStorage#chat.settings
     const stored =
-      settings !== null && settings.get('profilesettings')
+      settings !== null && this.authenticated && settings.get('profilesettings')
         ? settings
         : new Map(ChatStore.read('chat.settings') || []);
 
@@ -1118,6 +1118,14 @@ class Chat {
 
   onME(data) {
     this.setUser(data);
+    if (data) {
+      // If is a logged in user.
+      this.loadSettings();
+      this.loadWhispers();
+    } else {
+      // If guest load default settings.
+      this.setSettings();
+    }
   }
 
   onOPEN() {


### PR DESCRIPTION
Revert changes in #261, which resulted in a bug that prevented chat from loading for unregistered users.