### PR TITLE
Filter out last message rather than popping

### DIFF
--- a/assets/chat/js/window.js
+++ b/assets/chat/js/window.js
@@ -144,8 +144,8 @@ class ChatWindow extends EventEmitter {
   }
 
   removeLastMessage() {
-    const lastMessage = this.messages.pop();
-    lastMessage?.remove();
+    this.lastmessage.remove();
+    this.messages = this.messages.filter((m) => m !== this.lastmessage);
   }
 
   cleanupThrottle = throttle(50, this.cleanup);


### PR DESCRIPTION
Popping the last message from the array can cause problems if messages are received in rapid succession.