### PR TITLE
Clean up messages from beginning rather than end

### DIFF
--- a/assets/chat/js/window.js
+++ b/assets/chat/js/window.js
@@ -112,7 +112,7 @@ class ChatWindow extends EventEmitter {
           element.remove();
         });
 
-        this.messages = this.messages.slice(0, lines.length - this.maxlines);
+        this.messages = this.messages.slice(lines.length - this.maxlines);
       }
     }
   }


### PR DESCRIPTION
This fixes a bug where new messages could not be censored because they were cleaned up prematurely.