### PR TITLE
Add new error for users not allowed to chat

### DIFF
--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -77,6 +77,8 @@ const errorstrings = new Map(
     activepoll: 'Poll already started.',
     noactivepoll: 'No poll started.',
     alreadyvoted: 'You have already voted!',
+    nochatting:
+      "You aren't allowed to chat. Either you haven't picked a username, or a mod disabled your privileges.",
   })
 );
 


### PR DESCRIPTION
Due to a change in chat's authentication system, users who aren't allowed to chat can now authenticate. Their chat messages are now blocked via the chat backend.