### PR TITLE
Fix hash link parsing regex

### DIFF
--- a/assets/chat/js/formatters/EmbedUrlFormatter.js
+++ b/assets/chat/js/formatters/EmbedUrlFormatter.js
@@ -2,7 +2,7 @@ export default class EmbedUrlFormatter {
   constructor() {
     this.bigscreenPath = '/bigscreen';
     this.bigscreenregex =
-      /(^|\s)(#(twitch|twitch-vod|twitch-clip|youtube|youtube-live|facebook|rumble|vimeo)\/([\w-]{3,64}|\d{10,20}\/videos\/\d{10,20}|\w{7}\/\?pub=\w{5})(?:\?t=(\d+)s?)?(?:$|\?|&))\b/g;
+      /(^|\s)(#(twitch|twitch-vod|twitch-clip|youtube|youtube-live|facebook|rumble|vimeo)\/([\w-]{3,64}|\d{10,20}\/videos\/\d{10,20}|\w{7}\/\?pub=\w{5})(?:\?t=(\d+)s?)?)\b/g;
 
     try {
       const { location } = window.top || window.parent || window;


### PR DESCRIPTION
The broken regex was copied directly from `BigscreenManager` in website-private. It's used to identify if a URL's fragment is a valid embed hash link. The regex in `EmbedUrlFormatter` needs to identify hash links among other text in a chat message, so it's slightly different.