### PR TITLE
Issue #305 fix tagging with mixed case color

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1794,7 +1794,7 @@ class Chat {
     let note = '';
     if (parts[1]) {
       if (tagcolors.indexOf(parts[1]) !== -1) {
-        color = parts[1];
+        color = parts[1].toLowerCase();
         note = parts[2] ? parts.slice(2, parts.length).join(' ') : '';
       } else {
         color = tagcolors[Math.floor(Math.random() * tagcolors.length)];


### PR DESCRIPTION
Fixed tagging by adding a toLowerCase when we read the color param.

resolves #305 

![image](https://github.com/destinygg/chat-gui/assets/1808209/e093ad07-c393-45f6-8a08-aadab48ce931)
