### PR TITLE
Add timestamp support to youtube embeds

### DIFF
--- a/assets/chat/js/formatters/UrlFormatter.js
+++ b/assets/chat/js/formatters/UrlFormatter.js
@@ -76,7 +76,7 @@ export default class UrlFormatter {
 
         let embedHashLink = '';
         try {
-          embedHashLink = this.hashLinkConverter.convert(normalizedUrl);
+          embedHashLink = this.hashLinkConverter.convert(decodedUrl);
         } catch (err) {
           // ignore
         }

--- a/assets/chat/js/hashlinkconverter.js
+++ b/assets/chat/js/hashlinkconverter.js
@@ -24,6 +24,7 @@ class HashLinkConverter {
     const pathname = url.pathname.slice(1);
     let match;
     let videoId;
+    let timeStamp;
     switch (url.hostname) {
       case 'www.twitch.tv':
       case 'twitch.tv':
@@ -45,13 +46,19 @@ class HashLinkConverter {
           return `#youtube/${match[1]}`;
         }
         videoId = url.searchParams.get('v');
+        timeStamp = url.searchParams.get('amp;t');
         if (!videoId) {
           throw new Error(MISSING_VIDEO_ID_ERROR);
         }
-        return `#youtube/${videoId}`;
+        return timeStamp
+          ? `#youtube/${videoId}?t=${timeStamp}`
+          : `#youtube/${videoId}`;
       case 'www.youtu.be':
       case 'youtu.be':
-        return `#youtube/${pathname}`;
+        timeStamp = url.searchParams.get('t');
+        return timeStamp
+          ? `#youtube/${pathname}?t=${timeStamp}`
+          : `#youtube/${pathname}`;
       case 'www.rumble.com':
       case 'rumble.com':
         match = pathname.match(this.rumbleEmbedRegex);

--- a/assets/chat/js/hashlinkconverter.js
+++ b/assets/chat/js/hashlinkconverter.js
@@ -46,7 +46,7 @@ class HashLinkConverter {
           return `#youtube/${match[1]}`;
         }
         videoId = url.searchParams.get('v');
-        timestamp = url.searchParams.get('amp;t') || url.searchParams.get('t');
+        timestamp = url.searchParams.get('t');
         if (!videoId) {
           throw new Error(MISSING_VIDEO_ID_ERROR);
         }

--- a/assets/chat/js/hashlinkconverter.js
+++ b/assets/chat/js/hashlinkconverter.js
@@ -46,7 +46,7 @@ class HashLinkConverter {
           return `#youtube/${match[1]}`;
         }
         videoId = url.searchParams.get('v');
-        timeStamp = url.searchParams.get('amp;t');
+        timeStamp = url.searchParams.get('amp;t') || url.searchParams.get('t');
         if (!videoId) {
           throw new Error(MISSING_VIDEO_ID_ERROR);
         }

--- a/assets/chat/js/hashlinkconverter.js
+++ b/assets/chat/js/hashlinkconverter.js
@@ -24,7 +24,7 @@ class HashLinkConverter {
     const pathname = url.pathname.slice(1);
     let match;
     let videoId;
-    let timeStamp;
+    let timestamp;
     switch (url.hostname) {
       case 'www.twitch.tv':
       case 'twitch.tv':
@@ -46,18 +46,18 @@ class HashLinkConverter {
           return `#youtube/${match[1]}`;
         }
         videoId = url.searchParams.get('v');
-        timeStamp = url.searchParams.get('amp;t') || url.searchParams.get('t');
+        timestamp = url.searchParams.get('amp;t') || url.searchParams.get('t');
         if (!videoId) {
           throw new Error(MISSING_VIDEO_ID_ERROR);
         }
-        return timeStamp
-          ? `#youtube/${videoId}?t=${timeStamp}`
+        return timestamp
+          ? `#youtube/${videoId}?t=${timestamp}`
           : `#youtube/${videoId}`;
       case 'www.youtu.be':
       case 'youtu.be':
-        timeStamp = url.searchParams.get('t');
-        return timeStamp
-          ? `#youtube/${pathname}?t=${timeStamp}`
+        timestamp = url.searchParams.get('t');
+        return timestamp
+          ? `#youtube/${pathname}?t=${timestamp}`
           : `#youtube/${pathname}`;
       case 'www.rumble.com':
       case 'rumble.com':

--- a/assets/chat/js/hashlinkconverter.test.js
+++ b/assets/chat/js/hashlinkconverter.test.js
@@ -35,6 +35,16 @@ describe('Valid embeds', () => {
       '#youtube/dPmLveKE_wY',
     ],
     [
+      'Youtube video with timestamp',
+      'https://www.youtube.com/watch?v=tZ_gn0E87Qo&t=5',
+      '#youtube/tZ_gn0E87Qo?t=5',
+    ],
+    [
+      'Youtube video shortened link with timestamp',
+      'https://youtu.be/dPmLveKE_wY?t=5',
+      '#youtube/dPmLveKE_wY?t=5',
+    ],
+    [
       'Youtube live stream shareable link',
       'https://www.youtube.com/live/jfKfPfyJRdk?feature=share',
       '#youtube/jfKfPfyJRdk',


### PR DESCRIPTION
This adds timestamp support in the hash link converter so that we can embed youtube links with the right timestamp.