### PR TITLE
fix: only add embed icon to links if in chat

### DIFF
--- a/assets/chat/js/formatters/UrlFormatter.js
+++ b/assets/chat/js/formatters/UrlFormatter.js
@@ -88,9 +88,9 @@ export default class UrlFormatter {
         const extra = self.encodeUrl(decodedUrl.substring(m[0].length));
         const href = `${scheme ? '' : 'http://'}${normalizedUrl}`;
 
-        const embedTarget = chat.isBigscreenEmbed() ? '_top' : '_blank';
-        const embedUrl = `${chat.config.dggOrigin}${chat.bigscreenPath}${embedHashLink}`;
-        return embedHashLink
+        const embedTarget = chat?.isBigscreenEmbed() ? '_top' : '_blank';
+        const embedUrl = `${chat?.config.dggOrigin}${chat?.bigscreenPath}${embedHashLink}`;
+        return chat && embedHashLink
           ? `<a target="_blank" class="externallink ${extraclass}" href="${href}" rel="nofollow">${urlText}</a><a target="${embedTarget}" class="embed-button" href="${embedUrl}"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="14.4" viewBox="0 0 640 512"><path d="M64 64V352H576V64H64zM0 64C0 28.7 28.7 0 64 0H576c35.3 0 64 28.7 64 64V352c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V64zM128 448H512c17.7 0 32 14.3 32 32s-14.3 32-32 32H128c-17.7 0-32-14.3-32-32s14.3-32 32-32z"  fill="#fff"/></svg></a>`
           : `<a target="_blank" class="externallink ${extraclass}" href="${href}" rel="nofollow">${urlText}</a>${extra}`;
       }


### PR DESCRIPTION
Recent chat-gui link formatting PR (https://github.com/destinygg/chat-gui/pull/285) broke the [profile messages tab](https://www.destiny.gg/profile/messages): if any message has a link, it will loop "loading" them endlessly.

![image](https://github.com/destinygg/website-private/assets/41237021/5c414d1f-4b9d-43ba-9dec-6bf2bb645fce)

The reason is that the URL formatter tries to access some chat specific functions that are missing because the chat object in profile (```ctx```) is set to be empty. This PR requires the https://github.com/destinygg/website-private/pull/231 to be merged first to fix the issue.