### PR TITLE
fix: message history limit not applying

### DIFF
--- a/assets/chat/js/history.js
+++ b/assets/chat/js/history.js
@@ -71,7 +71,7 @@ class ChatInputHistory {
     this.history.push(message);
     // limit entries
     if (this.history.length > this.maxentries)
-      this.history.slice(-this.maxentries);
+      this.history.splice(0, this.history.length - this.maxentries);
     ChatStore.write('chat.history', this.history);
   }
 }


### PR DESCRIPTION
Apparently the message history (that is, your message history, the up/down arrow one) limit either never worked, or got broken at some point. I'd say this probably isn't an issue for most people, but some REALLY active chatters can chat SO MUCH that they fill up their entire local storage (since it has a 5 or 10 MB limit), which causes the embed bar to break and messages to not disappear from the input on 'send'.

![ksnip_20231121-130526](https://github.com/destinygg/chat-gui/assets/41237021/63cf518f-0b06-4002-baf2-607a0f2cd94e)
