### PR TITLE
fix: autocomplete usernames in lowercase

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -971,14 +971,13 @@ class Chat {
       if (data.recipient) {
         users.push(this.addUser(data.recipient));
       }
-      users.forEach((u) =>
-        {
-          const username = typeof u.username === 'string' ?
-            u.username.toLowerCase()
+      users.forEach((u) => {
+        const username =
+          typeof u.username === 'string'
+            ? u.username.toLowerCase()
             : u.username;
-          this.autocomplete.add(username, false, Date.now());
-        }
-      );
+        this.autocomplete.add(username, false, Date.now());
+      });
     }
   }
 

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -972,7 +972,12 @@ class Chat {
         users.push(this.addUser(data.recipient));
       }
       users.forEach((u) =>
-        this.autocomplete.add(u.username, false, Date.now()),
+        {
+          const username = typeof u.username === 'string' ?
+            u.username.toLowerCase()
+            : u.username;
+          this.autocomplete.add(username, false, Date.now());
+        }
       );
     }
   }


### PR DESCRIPTION
This change makes all usernames lowercase when tabbed for autocompletion.


<img width="610" alt="Screenshot 2023-11-28 013344" src="https://github.com/destinygg/chat-gui/assets/43797479/280aeecd-5b55-4793-b6aa-14ae86a0b589">
