### PR TITLE
Strip tracking params from YouTube links

### DIFF
--- a/assets/chat/js/formatters/UrlFormatter.js
+++ b/assets/chat/js/formatters/UrlFormatter.js
@@ -71,8 +71,7 @@ export default class UrlFormatter {
       const decodedUrl = self.elem.html(url).text();
       const m = decodedUrl.match(self.linkregex);
       if (m) {
-        const encodedUrl = self.encodeUrl(m[0]);
-        const normalizedUrl = this.normalizeUrl(encodedUrl);
+        const normalizedUrl = self.encodeUrl(this.normalizeUrl(m[0]));
 
         let embedHashLink = '';
         try {
@@ -112,6 +111,14 @@ export default class UrlFormatter {
       // Remove the query string from xeet URLs to protect users from clicking
       // on a link to a xeet they've already seen.
       return url.split('?')[0];
+    }
+
+    if (/youtu(?:be\.com|\.be)/i.test(url)) {
+      // Same as with xeets, remove the nasty share tracking query param
+      // from YouTube links.
+      const ytLink = new URL(url);
+      ytLink.searchParams.delete('si');
+      return ytLink.href;
     }
 
     return url;

--- a/assets/chat/js/formatters/UrlFormatter.test.js
+++ b/assets/chat/js/formatters/UrlFormatter.test.js
@@ -21,7 +21,37 @@ describe('Normalizing URLs', () => {
     );
   });
 
-  test("Don't modify a URL that isn't Twitter or X", () => {
+  test('Remove the share tracking query param from a youtube.com link', () => {
+    expect(
+      urlFormatter.normalizeUrl(
+        'https://www.youtube.com/live/2NjXXQYtUNY?si=5ALpT28ptRec6T7u&t=70',
+      ),
+    ).toBe('https://www.youtube.com/live/2NjXXQYtUNY?t=70');
+  });
+
+  test('Remove the share tracking query param from a youtu.be link', () => {
+    expect(
+      urlFormatter.normalizeUrl(
+        'https://youtu.be/SbPP1i6INPk?si=K0qpdHBGOIJ-gBMK&t=60',
+      ),
+    ).toBe('https://youtu.be/SbPP1i6INPk?t=60');
+  });
+
+  test("Don't modify a youtube.com link that doesn't contain the share tracking query param", () => {
+    expect(
+      urlFormatter.normalizeUrl(
+        'https://www.youtube.com/live/2NjXXQYtUNY?t=70',
+      ),
+    ).toBe('https://www.youtube.com/live/2NjXXQYtUNY?t=70');
+  });
+
+  test("Don't modify a youtu.be link that doesn't contain the share tracking query param", () => {
+    expect(urlFormatter.normalizeUrl('https://youtu.be/SbPP1i6INPk?t=60')).toBe(
+      'https://youtu.be/SbPP1i6INPk?t=60',
+    );
+  });
+
+  test("Don't modify a URL that isn't Twitter, X or YouTube", () => {
     expect(
       urlFormatter.normalizeUrl('https://www.twitch.tv/search?term=vtuber'),
     ).toBe('https://www.twitch.tv/search?term=vtuber');


### PR DESCRIPTION
Someone suggested it in chat this morning and I thought it was a cute idea.

Before:
![ksnip_20231227-150005](https://github.com/destinygg/chat-gui/assets/41237021/073c5472-1fac-4044-a9f5-68465946ce93)

After:
![ksnip_20231227-150116](https://github.com/destinygg/chat-gui/assets/41237021/affb6e99-97e0-48c8-8879-8f4253798911)

I had to change the order of link formatting to make this work: now it normalizes first, encodes second (otherwise it double encodes which messes up the link). I don't think it should change anything in the output.