### PR TITLE
Toggle watching focus btn active on click

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -372,6 +372,7 @@ class Chat {
     this.ui.on('click touch', '#chat-watching-focus-btn', () => {
       this.watchingfocus = !this.watchingfocus;
       this.ui.toggleClass('watching-focus', this.watchingfocus);
+      this.ui.find('#chat-watching-focus-btn').toggleClass('active');
     });
 
     // Chat focus / menu close when clicking on some areas


### PR DESCRIPTION
tbh may be better to separate this snippet into a `watching-focus.js` or add this into `focus.js` or something, but this pr is just a quick fix to indicate that watching focus is active. if the refactor to separate class is wanted can update to include that as well

#373 