### PR TITLE
don't apply watching focus if focus active

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -858,7 +858,7 @@ hr {
   }
 }
 
-.watching-focus {
+.watching-focus:not(.focus) {
   .msg-emote,
   .msg-user,
   .msg-death {
@@ -872,7 +872,7 @@ hr {
 }
 
 /* Focus or highlight a line */
-.focus:not(.watching-focus) .msg-chat {
+.focus .msg-chat {
   opacity: 0.3;
 
   &.msg-pinned {


### PR DESCRIPTION
i have very little experience with javascript so if there's some bad practice/ugly code stuff that needs fixed pls lmk

this should solve #372, sets a MutationObserver to check if `focus` is on the ui element classlist or not. If `focus` is added or removed, sets `watching-focus` state accordingly