### PR TITLE
fix: generate command autocomplete for mods correctly

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -346,9 +346,6 @@ class Chat {
       ),
     );
 
-    this.commands
-      .generateAutocomplete(this.user.hasModPowers())
-      .forEach((command) => this.autocomplete.add(command));
     this.autocomplete.bind(this);
 
     // Chat input
@@ -682,6 +679,11 @@ class Chat {
     const fontscale = this.settings.get('fontscale') || 'auto';
     $(document.body).toggleClass(`pref-fontscale`, fontscale !== 'auto');
     $(document.body).attr('data-fontscale', fontscale);
+
+    // Add command autocomplete
+    this.commands
+      .generateAutocomplete(this.user.hasModPowers())
+      .forEach((command) => this.autocomplete.add(command));
 
     for (const window of this.windows.values()) {
       window.updateMessages(this);

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -222,6 +222,9 @@ class Chat {
       this.user = this.addUser(user);
       this.authenticated = true;
     }
+    this.commands
+      .generateAutocomplete(this.user.hasModPowers())
+      .forEach((command) => this.autocomplete.add(command));
     this.setDefaultPlaceholderText();
     return this;
   }
@@ -679,11 +682,6 @@ class Chat {
     const fontscale = this.settings.get('fontscale') || 'auto';
     $(document.body).toggleClass(`pref-fontscale`, fontscale !== 'auto');
     $(document.body).attr('data-fontscale', fontscale);
-
-    // Add command autocomplete
-    this.commands
-      .generateAutocomplete(this.user.hasModPowers())
-      .forEach((command) => this.autocomplete.add(command));
 
     for (const window of this.windows.values()) {
       window.updateMessages(this);


### PR DESCRIPTION
Before this fix it only added perm-less commands, bc the user was getting assigned later in `onME`. I guess it broke when that event got added (or maybe it never worked right in the first place).

Anyway, this change fixes it.