### PR TITLE
DES-199: add an option to disable emote and flair animations

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -1717,18 +1717,18 @@ hr {
 .pref-autocompletehelper #chat-auto-complete.active {
   display: block;
 }
-.pref-disableemoteanimations .emote {
-  &,
-  &:hover,
-  &:before,
-  &:after {
+.pref-disableanimations {
+  .emote,
+  .emote:hover,
+  .emote::before,
+  .emote::after {
     animation: none !important;
   }
-}
 
-.pref-disableflairanimations a.user,
-.pref-disableflairanimations span.user {
-  animation: none !important;
+  a.user,
+  span.user {
+    animation: none !important;
+  }
 }
 
 /* OverlayScrollbars theme */

--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -1717,6 +1717,14 @@ hr {
 .pref-autocompletehelper #chat-auto-complete.active {
   display: block;
 }
+.pref-disableemoteanimations .emote {
+  &,
+  &:hover,
+  &:before,
+  &:after {
+    animation: none !important;
+  }
+}
 
 /* OverlayScrollbars theme */
 .dgg-scroller-theme.os-scrollbar-horizontal {

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -133,6 +133,7 @@ const settingsdefault = new Map(
     hidensfl: false,
     fontscale: 'auto',
     censorbadwords: false,
+    disableemoteanimations: false,
   }),
 );
 

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -133,8 +133,7 @@ const settingsdefault = new Map(
     hidensfl: false,
     fontscale: 'auto',
     censorbadwords: false,
-    disableemoteanimations: false,
-    disableflairanimations: false,
+    disableanimations: false,
   }),
 );
 

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -148,15 +148,9 @@
               </select>
             </div>
             <div class="form-group checkbox">
-              <label title="Disable non-GIF emote animations">
-                <input name="disableemoteanimations" type="checkbox" /> Disable
-                non-GIF emote animations
-              </label>
-            </div>
-            <div class="form-group checkbox">
-              <label title="Disable non-GIF flair animations">
-                <input name="disableflairanimations" type="checkbox" /> Disable
-                non-GIF flair animations
+              <label title="Disable animations when possible">
+                <input name="disableanimations" type="checkbox" /> Disable
+                animations when possible
               </label>
             </div>
 

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -147,6 +147,12 @@
                 <option value="2">do nothing</option>
               </select>
             </div>
+            <div class="form-group checkbox">
+              <label title="Disable non-GIF emote animations">
+                <input name="disableemoteanimations" type="checkbox" /> Disable
+                non-GIF emote animations
+              </label>
+            </div>
 
             <h4>Notifications</h4>
             <div class="form-group checkbox">


### PR DESCRIPTION
Adds an option to disable the emote animations (the GIF/APNG ones still work, since as far as I'm aware there's no simple way to turn them off) and the flair animations (the Tier V rainbow gradient thing, for example).

![image](https://github.com/destinygg/chat-gui/assets/41237021/9380ed44-a615-499c-b606-095c677f1181)

https://github.com/destinygg/chat-gui/assets/41237021/8cc1de8e-74a4-4c3b-8ce5-e66f7de16731


