### PR TITLE
Add an option to disable flair animations

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -1717,6 +1717,10 @@ hr {
 .pref-autocompletehelper #chat-auto-complete.active {
   display: block;
 }
+.pref-disableflairanimations a.user,
+.pref-disableflairanimations span.user {
+  animation: none !important;
+}
 
 /* OverlayScrollbars theme */
 .dgg-scroller-theme.os-scrollbar-horizontal {

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -133,6 +133,7 @@ const settingsdefault = new Map(
     hidensfl: false,
     fontscale: 'auto',
     censorbadwords: false,
+    disableflairanimations: false,
   }),
 );
 

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -147,6 +147,12 @@
                 <option value="2">do nothing</option>
               </select>
             </div>
+            <div class="form-group checkbox">
+              <label title="Disable non-GIF flair animations">
+                <input name="disableflairanimations" type="checkbox" /> Disable
+                non-GIF flair animations
+              </label>
+            </div>
 
             <h4>Notifications</h4>
             <div class="form-group checkbox">


### PR DESCRIPTION
In addition to https://github.com/destinygg/chat-gui/pull/420, I thought it would be nice to have an identical option, but for flairs/features/username colors (like the Tier V rolling rainbow gradient effect, which is the only one we have right now).

![image](https://github.com/destinygg/chat-gui/assets/41237021/913362ee-854d-4774-a6cd-6f97e275ffae)

https://github.com/destinygg/chat-gui/assets/41237021/78e7cef4-d222-45bb-b218-0316c070f482

