### PR TITLE
fix: `/me` messages in message history having the colon thingy

### DIFF
--- a/assets/chat/js/messages/ChatUserMessage.js
+++ b/assets/chat/js/messages/ChatUserMessage.js
@@ -117,4 +117,15 @@ export default class ChatUserMessage extends ChatMessage {
     this.ui.classList.toggle('msg-own', isOwn);
     this.isown = isOwn;
   }
+
+  /**
+   * @param {boolean} isSlashMe
+   */
+  setSlashMe(isSlashMe) {
+    this.ui.classList.toggle('msg-me', isSlashMe);
+    const ctrl = this.ui.querySelector('.ctrl');
+    if (ctrl) ctrl.textContent = isSlashMe ? '' : ': ';
+
+    this.slashme = isSlashMe;
+  }
 }

--- a/assets/chat/js/window.js
+++ b/assets/chat/js/window.js
@@ -135,6 +135,7 @@ class ChatWindow extends EventEmitter {
         message.highlight(chat.shouldHighlightMessage(message));
         if (message.type === MessageTypes.USER) {
           message.setContinued(this.isContinued(message, this.messages[i - 1]));
+          message.setSlashMe(message.slashme);
           message.setTag(chat.taggednicks.get(username));
         }
         message.setTagTitle(chat.taggednotes.get(username) ?? '');


### PR DESCRIPTION
Before:
![ksnip_20240216-145958](https://github.com/destinygg/chat-gui/assets/41237021/29210b2f-2069-4a1f-ab22-63a1aab98bf0)

After:
![ksnip_20240216-150022](https://github.com/destinygg/chat-gui/assets/41237021/1db61788-69a2-4b08-8dcb-56caee797cd6)
