### PR TITLE
fix: update regex to include apostrophes in MentionedUserFormatter

### DIFF
--- a/assets/chat/js/formatters/MentionedUserFormatter.js
+++ b/assets/chat/js/formatters/MentionedUserFormatter.js
@@ -3,7 +3,7 @@ export default class MentionedUserFormatter {
     if (message && message.mentioned && message.mentioned.length > 0) {
       return str.replace(
         new RegExp(
-          `((?:^|\\s)@?)(${message.mentioned.join('|')})(?=$|\\s|[.?!,])`,
+          `((?:^|\\s)@?)(${message.mentioned.join('|')})(?=$|\\s|[.?!,'])`,
           'igm',
         ),
         `$1<span class="chat-user">$2</span>`,


### PR DESCRIPTION
- Adjust the regular expression in the `format` method to correctly match mentions followed by an apostrophe, ensuring that names like "77Y's" are highlighted as expected.