### PR TITLE
add enterkeyhint property to chat textarea

### DIFF
--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -30,6 +30,7 @@
   <div id="chat-input-frame">
     <div id="chat-input-wrap">
       <textarea
+        enterkeyhint="send"
         id="chat-input-control"
         placeholder="Getting things ready ..."
         autocomplete="off"


### PR DESCRIPTION
this PR is for this open issue: https://github.com/destinygg/chat-gui/issues/455

change the enter key to show "send" on virtual keyboards.

iphone virtual keyboard after the change:
![Simulator Screen Shot - iPhone 13 Pro - 2024-05-08 at 23 44 59](https://github.com/destinygg/chat-gui/assets/14094188/e9e0e376-4f48-43e5-94b6-2f5c84c634d7)

