### PR TITLE
Add new color for spoilers links

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -348,6 +348,11 @@ hr {
     border-color: transparent transparent $color-underline-nsfl transparent;
     border-width: 1px 0 1px 0;
   }
+  .spoilers-link {
+    border-style: dashed;
+    border-color: transparent transparent $color-underline-spoilers transparent;
+    border-width: 1px 0 1px 0;
+  }
   .hidden {
     display: none !important;
   }

--- a/assets/chat/js/formatters/EmbedUrlFormatter.js
+++ b/assets/chat/js/formatters/EmbedUrlFormatter.js
@@ -10,7 +10,8 @@ export default class EmbedUrlFormatter {
     let extraclass = '';
 
     if (/\b(?:NSFL)\b/i.test(str)) extraclass = 'nsfl-link';
-    else if (/\b(?:NSFW|SPOILERS?)\b/i.test(str)) extraclass = 'nsfw-link';
+    else if (/\b(?:NSFW)\b/i.test(str)) extraclass = 'nsfw-link';
+    else if (/\b(?:SPOILERS)\b/i.test(str)) extraclass = 'spoilers-link';
 
     const baseUrl = chat.config.dggOrigin + chat.bigscreenPath;
     return str.replace(

--- a/assets/chat/js/formatters/UrlFormatter.js
+++ b/assets/chat/js/formatters/UrlFormatter.js
@@ -15,7 +15,8 @@ export default class UrlFormatter {
     let extraclass = '';
 
     if (/\b(?:NSFL)\b/i.test(str)) extraclass = 'nsfl-link';
-    else if (/\b(?:NSFW|SPOILERS?)\b/i.test(str)) extraclass = 'nsfw-link';
+    else if (/\b(?:NSFW)\b/i.test(str)) extraclass = 'nsfw-link';
+    else if (/\b(?:SPOILERS)\b/i.test(str)) extraclass = 'spoilers-link';
 
     return str.replace(linkregex, (url, scheme) => {
       const decodedUrl = self.elem.html(url).text();

--- a/assets/common.scss
+++ b/assets/common.scss
@@ -37,6 +37,7 @@ $color-link-visited: #a66be5;
 $color-text-broadcast: #edea12;
 $color-underline-nsfl: #fff000;
 $color-underline-nsfw: #ff0000;
+$color-underline-spoilers: #ff80ce;
 
 $color-green: #61bd4f;
 $color-darkgreen: #4c7c42;


### PR DESCRIPTION
Spoilers links will have a dashed pink underline. The issue suggested orange, but I think it will be hard to differentiate from red and yellow. Closes #471 

![ff80ce](https://github.com/destinygg/chat-gui/assets/60011372/6f9d2169-e2e1-4075-aeab-61e668ae9b83)
![ff80ce-visited](https://github.com/destinygg/chat-gui/assets/60011372/0f5d03f7-b387-4e43-9616-5f1ec9250b92)
