### PR TITLE
fix: ignore combos

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1129,9 +1129,7 @@ class Chat {
 
     if (isCombo && win.lastmessage?.type === MessageTypes.USER) {
       win.removeLastMessage();
-      const msg = MessageBuilder.emote(textonly, usr, data.timestamp, 2).into(
-        this,
-      );
+      const msg = MessageBuilder.emote(textonly, data.timestamp, 2).into(this);
 
       if (this.user.equalWatching(usr.watching)) {
         msg.ui.classList.add('watching-same');

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1129,7 +1129,9 @@ class Chat {
 
     if (isCombo && win.lastmessage?.type === MessageTypes.USER) {
       win.removeLastMessage();
-      const msg = MessageBuilder.emote(textonly, data.timestamp, 2).into(this);
+      const msg = MessageBuilder.emote(textonly, usr, data.timestamp, 2).into(
+        this,
+      );
 
       if (this.user.equalWatching(usr.watching)) {
         msg.ui.classList.add('watching-same');

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -799,7 +799,7 @@ class Chat {
     win.addMessage(this, message);
 
     // Hide the message if the user is ignored
-    if (message.user && this.ignored(message.user.username, message.message)) {
+    if (this.ignored(message.user?.username, message.message)) {
       message.ignore();
     }
 

--- a/assets/chat/js/messages/ChatEmoteMessage.js
+++ b/assets/chat/js/messages/ChatEmoteMessage.js
@@ -27,9 +27,8 @@ function ChatEmoteMessageCount(message) {
 const ChatEmoteMessageCountThrottle = throttle(63, ChatEmoteMessageCount);
 
 export default class ChatEmoteMessage extends ChatMessage {
-  constructor(emote, user, timestamp, count = 1) {
+  constructor(emote, timestamp, count = 1) {
     super(emote, timestamp, MessageTypes.EMOTE);
-    this.user = user;
     this.emotecount = count;
     this.emoteFormatter = new EmoteFormatter();
   }

--- a/assets/chat/js/messages/ChatEmoteMessage.js
+++ b/assets/chat/js/messages/ChatEmoteMessage.js
@@ -27,8 +27,9 @@ function ChatEmoteMessageCount(message) {
 const ChatEmoteMessageCountThrottle = throttle(63, ChatEmoteMessageCount);
 
 export default class ChatEmoteMessage extends ChatMessage {
-  constructor(emote, timestamp, count = 1) {
+  constructor(emote, user, timestamp, count = 1) {
     super(emote, timestamp, MessageTypes.EMOTE);
+    this.user = user;
     this.emotecount = count;
     this.emoteFormatter = new EmoteFormatter();
   }

--- a/assets/chat/js/window.js
+++ b/assets/chat/js/window.js
@@ -127,11 +127,18 @@ class ChatWindow extends EventEmitter {
         message.updateTimeFormat();
       }
 
-      if (message.user && !message.user.isSystem()) {
-        const { username } = message.user;
+      if (message.user?.isSystem()) {
+        return;
+      }
 
-        message.setOwnMessage(username === chat.user.username);
+      const username = message.user?.username;
+
+      if (message.type !== MessageTypes.UI) {
         message.ignore(chat.ignored(username, message.message));
+      }
+
+      if (username) {
+        message.setOwnMessage(username === chat.user.username);
         message.highlight(chat.shouldHighlightMessage(message));
         if (message.type === MessageTypes.USER) {
           message.setContinued(this.isContinued(message, this.messages[i - 1]));


### PR DESCRIPTION
Adds a user to the `EMOTE` msg type so that the ignore function works properly with them (some people would harsh ignore emotes, but combos would still show up).