### PR TITLE
fix: don't create user list on onstream chat

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -345,14 +345,16 @@ class Chat {
         this,
       ),
     );
-    this.menus.set(
-      'users',
-      new ChatUserMenu(
-        this.ui.find('#chat-user-list'),
-        this.ui.find('#chat-users-btn'),
-        this,
-      ),
-    );
+    if (this.ui.find('#chat-user-list').length > 0) {
+      this.menus.set(
+        'users',
+        new ChatUserMenu(
+          this.ui.find('#chat-user-list'),
+          this.ui.find('#chat-users-btn'),
+          this,
+        ),
+      );
+    }
     this.menus.set(
       'whisper-users',
       new ChatWhisperUsers(


### PR DESCRIPTION
Creating the user menu while the element containing it doesn't exist (like with on-stream chat, for example) leads to detached DOM nodes getting spam-created and potentially never cleaned up.

![Screenshot_20240702_080401](https://github.com/destinygg/chat-gui/assets/41237021/48220b18-8e33-4315-a63c-332b8b72c93d)

10 minutes later:
![Screenshot_20240702_081515](https://github.com/destinygg/chat-gui/assets/41237021/e44ac37d-d110-4087-8975-99ecfa4bf0e7)

I'm not sure if this actually causes any real performance issues/memory leaks, but it's better to have it fixed anyway.