### PR TITLE
fix: close chat menus on input box click

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -413,6 +413,11 @@ class Chat {
       this.focusIfNothingSelected();
     });
 
+    // Close menus when the input box textarea is clicked
+    this.input.on('click', () => {
+      ChatMenu.closeMenus(this);
+    });
+
     // ESC
     document.addEventListener('keydown', (e) => {
       if (isKeyCode(e, KEYCODES.ESC)) ChatMenu.closeMenus(this); // ESC key


### PR DESCRIPTION
the input box wrapper closes the menus when you click it but it didn't apply to the actual textarea where you type messages