### PR TITLE
Fix NSFW/NSFL link tagging

### DIFF
--- a/assets/chat/css/messages/_base.scss
+++ b/assets/chat/css/messages/_base.scss
@@ -58,13 +58,13 @@ $link-color-map: (
     &:focus {
       color: a.$color-link-hover;
     }
+  }
 
-    @each $type, $color in $link-color-map {
-      .#{$type}-link {
-        border-style: dashed;
-        border-width: 1px 0 1px 0;
-        border-color: transparent transparent $color transparent;
-      }
+  @each $type, $color in $link-color-map {
+    .#{$type}-link {
+      border-style: dashed;
+      border-width: 1px 0 1px 0;
+      border-color: transparent transparent $color transparent;
     }
   }
 


### PR DESCRIPTION
NSFW link styles were mistakenly applied to descendants of `.externallink` when they should be applied to descendants of `.msg-chat`.