### PR TITLE
Added hotkey for ESC key to scroll chat to bottom

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -416,10 +416,11 @@ class Chat {
     // ESC
     document.addEventListener('keydown', (e) => {
       if (isKeyCode(e, KEYCODES.ESC)) {
+        const activeView = this.getActiveWindow().scrollplugin;
         // If any menus are open, close them first
-        if ([...this.menus].some(([, menu]) => menu.visible)) ChatMenu.closeMenus(this);
+        if (this.getActiveMenu() !== undefined) ChatMenu.closeMenus(this);
         // If the active window is scrolled up (not pinned), scroll to bottom
-        else if (!this.getActiveWindow().scrollplugin.pinned) this.getActiveWindow().scrollplugin.scrollBottom();
+        else if (!activeView.pinned) activeView.scrollBottom();
       }
     });
 
@@ -925,6 +926,10 @@ class Chat {
     this.windowselect.toggle(this.windows.size > 1);
 
     if (this.mainwindow !== null) this.mainwindow.update();
+  }
+
+  getActiveMenu() {
+    return [...this.menus.values()].find((menu) => menu.visible);
   }
 
   censor(nick) {

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -417,11 +417,9 @@ class Chat {
     document.addEventListener('keydown', (e) => {
       if (isKeyCode(e, KEYCODES.ESC)) {
         // If any menus are open, close them first
-        if ([...this.menus].some(([, menu]) => menu.visible))
-          ChatMenu.closeMenus(this);
-        // If chat is not pinned, scroll to bottom
-        else if (!this.getActiveWindow().scrollplugin.pinned)
-          this.getActiveWindow().scrollplugin.scrollBottom();
+        if ([...this.menus].some(([, menu]) => menu.visible)) ChatMenu.closeMenus(this);
+        // If the active window is scrolled up (not pinned), scroll to bottom
+        else if (!this.getActiveWindow().scrollplugin.pinned) this.getActiveWindow().scrollplugin.scrollBottom();
       }
     });
 

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -417,9 +417,11 @@ class Chat {
     document.addEventListener('keydown', (e) => {
       if (isKeyCode(e, KEYCODES.ESC)) {
         // If any menus are open, close them first
-        if ([...this.menus].some(([, menu]) => menu.visible)) ChatMenu.closeMenus(this);
+        if ([...this.menus].some(([, menu]) => menu.visible))
+          ChatMenu.closeMenus(this);
         // If chat is not pinned, scroll to bottom
-        else if (!this.mainwindow.scrollplugin.pinned) this.mainwindow.scrollplugin.scrollBottom();
+        else if (!this.getActiveWindow().scrollplugin.pinned)
+          this.getActiveWindow().scrollplugin.scrollBottom();
       }
     });
 

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -444,6 +444,8 @@ class Chat {
           this.eventBar.unselect();
         } else if (!activeWindow.isScrollPinned()) {
           activeWindow.scrollBottom();
+        } else if (this.userfocus.isFocused()) {
+          this.userfocus.clearFocus();
         }
       }
     });

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -437,11 +437,11 @@ class Chat {
     // ESC
     document.addEventListener('keydown', (e) => {
       if (isKeyCode(e, KEYCODES.ESC)) {
-        const activeView = this.getActiveWindow().scrollplugin;
+        const activeWindow = this.getActiveWindow();
         // If any menus are open, close them first
         if (this.getActiveMenu()) ChatMenu.closeMenus(this);
         // If the active window is scrolled up (not pinned), scroll to bottom
-        else if (!activeView.pinned) activeView.scrollBottom();
+        else if (!activeWindow.isScrollPinned()) activeWindow.scrollBottom();
       }
     });
 

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -418,7 +418,7 @@ class Chat {
       if (isKeyCode(e, KEYCODES.ESC)) {
         const activeView = this.getActiveWindow().scrollplugin;
         // If any menus are open, close them first
-        if (this.getActiveMenu() !== undefined) ChatMenu.closeMenus(this);
+        if (this.getActiveMenu()) ChatMenu.closeMenus(this);
         // If the active window is scrolled up (not pinned), scroll to bottom
         else if (!activeView.pinned) activeView.scrollBottom();
       }

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -438,10 +438,13 @@ class Chat {
     document.addEventListener('keydown', (e) => {
       if (isKeyCode(e, KEYCODES.ESC)) {
         const activeWindow = this.getActiveWindow();
-        // If any menus are open, close them first
-        if (this.getActiveMenu()) ChatMenu.closeMenus(this);
-        // If the active window is scrolled up (not pinned), scroll to bottom
-        else if (!activeWindow.isScrollPinned()) activeWindow.scrollBottom();
+        if (this.getActiveMenu()) {
+          ChatMenu.closeMenus(this);
+        } else if (this.eventBar.isEventSelected()) {
+          this.eventBar.unselect();
+        } else if (!activeWindow.isScrollPinned()) {
+          activeWindow.scrollBottom();
+        }
       }
     });
 

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -415,7 +415,12 @@ class Chat {
 
     // ESC
     document.addEventListener('keydown', (e) => {
-      if (isKeyCode(e, KEYCODES.ESC)) ChatMenu.closeMenus(this); // ESC key
+      if (isKeyCode(e, KEYCODES.ESC)) {
+        // If any menus are open, close them first
+        if ([...this.menus].some(([, menu]) => menu.visible)) ChatMenu.closeMenus(this);
+        // If chat is not pinned, scroll to bottom
+        else if (!this.mainwindow.scrollplugin.pinned) this.mainwindow.scrollplugin.scrollBottom();
+      }
     });
 
     // Visibility

--- a/assets/chat/js/event-bar/EventBar.js
+++ b/assets/chat/js/event-bar/EventBar.js
@@ -69,7 +69,7 @@ export default class ChatEventBar extends EventEmitter {
    * Unselects the currently highlighted event.
    */
   unselect() {
-    if (this.eventSelectUI.hasChildNodes()) {
+    if (this.isEventSelected()) {
       this.eventSelectUI.replaceChildren();
       this.eventSelectUI.classList.add('hidden');
       this.emit('eventUnselected');
@@ -89,6 +89,13 @@ export default class ChatEventBar extends EventEmitter {
     this.eventSelectUI.classList.remove('hidden');
 
     this.emit('eventSelected');
+  }
+
+  /**
+   * Returns true if an event is currently selected
+   */
+  isEventSelected() {
+    return this.eventSelectUI.hasChildNodes();
   }
 
   /**

--- a/assets/chat/js/focus.js
+++ b/assets/chat/js/focus.js
@@ -24,7 +24,7 @@ class ChatUserFocus {
       this.toggleFocus(t.text());
     } else if (t.hasClass('flair')) {
       this.toggleFocus(t.data('flair'), true);
-    } else if (this.focused.length > 0) {
+    } else if (this.isFocused()) {
       this.clearFocus();
     }
   }
@@ -41,6 +41,10 @@ class ChatUserFocus {
     }
 
     return this;
+  }
+
+  isFocused() {
+    return this.focused.length > 0;
   }
 
   addCssRule(value, isFlair) {
@@ -92,7 +96,7 @@ class ChatUserFocus {
   }
 
   redraw() {
-    this.chat.ui.toggleClass('focus', this.focused.length > 0);
+    this.chat.ui.toggleClass('focus', this.isFocused());
   }
 }
 

--- a/assets/chat/js/window.js
+++ b/assets/chat/js/window.js
@@ -117,6 +117,14 @@ class ChatWindow extends EventEmitter {
     }
   }
 
+  isScrollPinned() {
+    return this.scrollplugin.pinned;
+  }
+
+  scrollBottom() {
+    this.scrollplugin.scrollBottom();
+  }
+
   /**
    * Use chat state (settings and authentication data) to update the messages in
    * this window.


### PR DESCRIPTION
This update introduces a hotkey function similar to Discord's. When the chat window is scrolled up, pressing `ESC` will bring the view back to the latest messages.

In DGG, if the chat is not already pinned to the bottom, pressing `ESC` will scroll it down. However, if any menus are open (e.g., emote or settings), `ESC` will first close those menus instead of scrolling. Scrolling will only occur when there are no other actions for `ESC` to perform.