### PR TITLE
fix: jumpy chat in firefox

### DIFF
--- a/assets/chat/css/chat/_output.scss
+++ b/assets/chat/css/chat/_output.scss
@@ -15,6 +15,7 @@
   font-family: a.$chat-lines-font;
   line-height: 1.65em;
   outline: 0 !important;
+  overflow-anchor: none;
 }
 
 .onstreamchat {


### PR DESCRIPTION
Noticed this happening a few months ago, but thought it was only on my end since no one else in chat was complaining (and I was having similar-ish 'ghost frame' issues on Linux before). A week ago someone reported the exact same issue happening on my website as well though (just in a much more exaggerated manner) https://github.com/vyneer/orvods-go/issues/38, so it must be more widespread than I thought initially.

<details>
<summary>Example 1</summary>

Normal speed:

https://github.com/user-attachments/assets/20fd9f12-98ea-442e-8b7e-09853326b148

Slowed down:

https://github.com/user-attachments/assets/0dc5eba6-5959-4e88-84d8-e0b04bfbc7e3

</details>

<details>
<summary>Example 2</summary>

Normal speed:

https://github.com/user-attachments/assets/2a13e761-ce89-43b5-bbd8-3ea259070994

Slowed down:

https://github.com/user-attachments/assets/5a3beb1d-75b7-44ef-bbe1-3255981f648e

</details>

I ran with the rule on for a bit of time now and had no issues. I tested a little bit with Chrome as well, and it doesn't seem to change the behavior there at all. On-stream chat also seems fine from a quick test.