### PR TITLE
Move draggable menus outside of iframe when possible

### DIFF
--- a/assets/chat/js/menus/ChatMenuFloating.js
+++ b/assets/chat/js/menus/ChatMenuFloating.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import ChatMenu from './ChatMenu';
 
 export default class ChatMenuFloating extends ChatMenu {
@@ -14,7 +15,24 @@ export default class ChatMenuFloating extends ChatMenu {
     this.y1 = 0;
     this.y2 = 0;
 
+    this.viewChain = [window];
+
     if (this.draggable?.length) {
+      while (this.viewChain[0] !== window.top) {
+        try {
+          // Access href to check if we have permissions for parent view
+          this.viewChain[0].parent.location.href;
+          this.viewChain.splice(0, 0, this.viewChain[0].parent);
+        } catch {
+          break;
+        }
+      }
+      this.viewChain.reverse();
+      
+      // Lift the ui up to the top of the chain
+      this.ui.css('pointer-events', 'auto');
+      this.ui.detach().appendTo(this.getContainer(this.viewChain[this.viewChain.length - 1]));
+      
       this.draggable[0].style.cursor = 'grab';
       this.draggable.on('mouseup', (e) => {
         e.preventDefault();
@@ -37,10 +55,13 @@ export default class ChatMenuFloating extends ChatMenu {
 
   drag(e) {
     if (this.mousedown) {
-      this.x2 = this.x1 - e.clientX;
-      this.y2 = this.y1 - e.clientY;
-      this.x1 = e.clientX;
-      this.y1 = e.clientY;
+      const offset = this.getViewOffset(e.view);
+      if (offset === null) return console.log(e.view);
+
+      this.x2 = this.x1 - (e.clientX + offset.x);
+      this.y2 = this.y1 - (e.clientY + offset.y);
+      this.x1 = (e.clientX + offset.x);
+      this.y1 = (e.clientY + offset.y);
 
       this.draggable[0].style.cursor = 'grabbing';
       this.ui[0].style.left = `${this.ui[0].offsetLeft - this.x2}px`;
@@ -53,6 +74,9 @@ export default class ChatMenuFloating extends ChatMenu {
   position(e) {
     this.mousedown = false;
     const rect = this.chat.output[0].getBoundingClientRect();
+    const offset = this.getViewOffset(e.view);
+    e.clientX += offset.x;
+    e.clientY += offset.y;
     // calculating floating window location (if it doesn't fit on screen, adjusting it a bit so it does)
     const x =
       this.ui.width() + e.clientX > rect.width
@@ -68,5 +92,67 @@ export default class ChatMenuFloating extends ChatMenu {
 
     this.ui[0].style.left = `${x}px`;
     this.ui[0].style.top = `${y}px`;
+  }
+
+  getViewOffset(view = window) {
+    let x = 0, y = 0;
+
+    // Iterate up the chain until we find the target view (skip iframes deeper than this one)
+    let i = 0;
+    for (; i < this.viewChain.length && this.viewChain[i] !== view; i++);
+    if (i >= this.viewChain.length) return null; // View isn't part of our chain
+
+    // Calculate offsets for the remainder of the chain
+    for (; i < this.viewChain.length - 1; i++) {
+      const frameRect = this.viewChain[i].frameElement.getBoundingClientRect();
+      x += frameRect.left;
+      y += frameRect.top;
+    }
+    return { x, y };
+  }
+
+  // Not using JQuery here as it doesn't always play nice with shadowDom
+  getContainer(view) {
+    let container = view.document.getElementById('#chat-gui__floating-window-container');
+    let shadow = container?.shadowRoot;
+    if (!shadow) {
+      container = document.createElement('div');
+      container.id = 'chat-gui__floating-window-container';
+      view.document.body.appendChild(container);
+
+      shadow = container.attachShadow({ mode: 'open' });
+      shadow.innerHTML = '<div style="position:absolute;left:0;top:0;right:0;bottom:0;pointer-events:none;overflow:hidden;">';
+      
+      const style = document.createElement('style');
+      for (const stylesheet of document.styleSheets) {
+        if (stylesheet.href) {
+          // Link to external stylesheets
+          const link = document.createElement('link');
+          link.rel = 'stylesheet';
+          link.href = stylesheet.href;
+          shadow.appendChild(link);
+        } else if (stylesheet.cssRules) {
+          // Inline or embedded stylesheets
+          const style = document.createElement('style');
+          for (const rule of stylesheet.cssRules) {
+              style.appendChild(document.createTextNode(rule.cssText));
+          }
+          shadow.appendChild(style);
+        }
+      }
+      // Add emotes and flairs as well (these are loaded after GUI is created, so don't exist yet)
+      {
+        const emotes = document.createElement('link');
+        emotes.rel = 'stylesheet';
+        emotes.href = `${this.chat.config.cdn.base}/emotes/emotes.css?_=${this.chat.config.cacheKey}`,
+        shadow.appendChild(emotes);
+        const flairs = document.createElement('link');
+        flairs.rel = 'stylesheet';
+        flairs.href = `${this.chat.config.cdn.base}/flairs/flairs.css?_=${this.chat.config.cacheKey}`,
+        shadow.appendChild(flairs);
+      }
+      shadow.appendChild(style);
+    }
+    return shadow.firstChild;
   }
 }

--- a/assets/chat/js/menus/ChatMenuFloating.js
+++ b/assets/chat/js/menus/ChatMenuFloating.js
@@ -28,11 +28,13 @@ export default class ChatMenuFloating extends ChatMenu {
         }
       }
       this.viewChain.reverse();
-      
+
       // Lift the ui up to the top of the chain
       this.ui.css('pointer-events', 'auto');
-      this.ui.detach().appendTo(this.getContainer(this.viewChain[this.viewChain.length - 1]));
-      
+      this.ui
+        .detach()
+        .appendTo(this.getContainer(this.viewChain[this.viewChain.length - 1]));
+
       this.draggable[0].style.cursor = 'grab';
       this.draggable.on('mouseup', (e) => {
         e.preventDefault();
@@ -61,8 +63,8 @@ export default class ChatMenuFloating extends ChatMenu {
 
       this.x2 = this.x1 - (e.clientX + offset.x);
       this.y2 = this.y1 - (e.clientY + offset.y);
-      this.x1 = (e.clientX + offset.x);
-      this.y1 = (e.clientY + offset.y);
+      this.x1 = e.clientX + offset.x;
+      this.y1 = e.clientY + offset.y;
 
       this.draggable[0].style.cursor = 'grabbing';
       this.ui[0].style.left = `${this.ui[0].offsetLeft - this.x2}px`;
@@ -87,7 +89,7 @@ export default class ChatMenuFloating extends ChatMenu {
           (rect.height - (this.ui.height() + e.clientY)) -
           12
         : e.clientY - rect.top - 12;
-        
+
     const offset = this.getViewOffset(e.view);
 
     this.ui[0].style.left = `${x + offset.x}px`;
@@ -95,7 +97,8 @@ export default class ChatMenuFloating extends ChatMenu {
   }
 
   getViewOffset(view = window) {
-    let x = 0, y = 0;
+    let x = 0,
+      y = 0;
 
     // Iterate up the chain until we find the target view (skip iframes deeper than this one)
     let i = 0;
@@ -113,7 +116,9 @@ export default class ChatMenuFloating extends ChatMenu {
 
   // Not using JQuery here as it doesn't always play nice with shadowDom
   getContainer(view) {
-    let container = view.document.getElementById('#chat-gui__floating-window-container');
+    let container = view.document.getElementById(
+      '#chat-gui__floating-window-container',
+    );
     let shadow = container?.shadowRoot;
     if (!shadow) {
       container = document.createElement('div');
@@ -121,8 +126,9 @@ export default class ChatMenuFloating extends ChatMenu {
       view.document.body.appendChild(container);
 
       shadow = container.attachShadow({ mode: 'open' });
-      shadow.innerHTML = '<div style="position:absolute;left:0;top:0;right:0;bottom:0;pointer-events:none;overflow:hidden;">';
-      
+      shadow.innerHTML =
+        '<div style="position:absolute;left:0;top:0;right:0;bottom:0;pointer-events:none;overflow:hidden;">';
+
       const style = document.createElement('style');
       for (const stylesheet of document.styleSheets) {
         if (stylesheet.href) {
@@ -135,7 +141,7 @@ export default class ChatMenuFloating extends ChatMenu {
           // Inline or embedded stylesheets
           const style = document.createElement('style');
           for (const rule of stylesheet.cssRules) {
-              style.appendChild(document.createTextNode(rule.cssText));
+            style.appendChild(document.createTextNode(rule.cssText));
           }
           shadow.appendChild(style);
         }
@@ -144,12 +150,12 @@ export default class ChatMenuFloating extends ChatMenu {
       {
         const emotes = document.createElement('link');
         emotes.rel = 'stylesheet';
-        emotes.href = `${this.chat.config.cdn.base}/emotes/emotes.css?_=${this.chat.config.cacheKey}`,
-        shadow.appendChild(emotes);
+        (emotes.href = `${this.chat.config.cdn.base}/emotes/emotes.css?_=${this.chat.config.cacheKey}`),
+          shadow.appendChild(emotes);
         const flairs = document.createElement('link');
         flairs.rel = 'stylesheet';
-        flairs.href = `${this.chat.config.cdn.base}/flairs/flairs.css?_=${this.chat.config.cacheKey}`,
-        shadow.appendChild(flairs);
+        (flairs.href = `${this.chat.config.cdn.base}/flairs/flairs.css?_=${this.chat.config.cacheKey}`),
+          shadow.appendChild(flairs);
       }
       shadow.appendChild(style);
     }

--- a/assets/chat/js/menus/ChatMenuFloating.js
+++ b/assets/chat/js/menus/ChatMenuFloating.js
@@ -41,8 +41,9 @@ export default class ChatMenuFloating extends ChatMenu {
       this.draggable.on('mousedown', (e) => {
         e.preventDefault();
         this.mousedown = true;
-        this.x1 = e.clientX;
-        this.y1 = e.clientY;
+        const offset = this.getViewOffset(e.view);
+        this.x1 = e.clientX + offset.x;
+        this.y1 = e.clientY + offset.y;
       });
       this.chat.output.on('mousemove', (e) => {
         this.drag(e);
@@ -74,9 +75,6 @@ export default class ChatMenuFloating extends ChatMenu {
   position(e) {
     this.mousedown = false;
     const rect = this.chat.output[0].getBoundingClientRect();
-    const offset = this.getViewOffset(e.view);
-    e.clientX += offset.x;
-    e.clientY += offset.y;
     // calculating floating window location (if it doesn't fit on screen, adjusting it a bit so it does)
     const x =
       this.ui.width() + e.clientX > rect.width
@@ -89,9 +87,11 @@ export default class ChatMenuFloating extends ChatMenu {
           (rect.height - (this.ui.height() + e.clientY)) -
           12
         : e.clientY - rect.top - 12;
+        
+    const offset = this.getViewOffset(e.view);
 
-    this.ui[0].style.left = `${x}px`;
-    this.ui[0].style.top = `${y}px`;
+    this.ui[0].style.left = `${x + offset.x}px`;
+    this.ui[0].style.top = `${y + offset.y}px`;
   }
 
   getViewOffset(view = window) {


### PR DESCRIPTION
This PR allows draggable menus (I think ChatUserInfoMenu is the only one atm) to be dragged anywhere on the page when chat is embedded as an iframe (i.e. it can escape the iframe bounds).

Sometimes this may not be possible as some sites have restrictions on what an iframe is able to control on the parent page, in which case it will behave as it currently does and clip to the iframe bounds.

This also supports arbitrarily nested iframes (for example if you had an iframe with bigscreen in, the menus from the chat in there would be able to be dragged anywhere on the page.

https://github.com/user-attachments/assets/fd73d723-62a8-4ef1-9b32-9bf4d39ff2c7