### PR TITLE
Fix error when publishing new version

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -24,6 +24,9 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
+      - name: Install Node.js dependencies
+        run: npm ci
+
       - name: Bump version
         id: bump
         env:


### PR DESCRIPTION
A recent PR modified the `prepare` script to use `shx` for Windows interoperability. The `prepare` script is special in that npm always runs it before `npm publish`. This resulted in an error during the execution of our "bump and release" workflow because the workflow doesn't install any Node dependencies.

Simply installing Node dependencies in the workflow fixes the issue. This has the added benefit of catching any last-second formatting or linter errors that slipped through the cracks.