### PR TITLE
fix: megaphone icon shrinking if there's too much text

### DIFF
--- a/assets/chat/css/messages/event/_event.scss
+++ b/assets/chat/css/messages/event/_event.scss
@@ -37,7 +37,6 @@
     text-decoration: none;
     display: inline-block;
     border: 0.25em solid transparent;
-    flex-shrink: 0;
     opacity: 0.75;
     width: 100%;
     height: 100%;
@@ -54,6 +53,7 @@
   .event-button {
     width: 2.25em;
     height: 2.25em;
+    flex-shrink: 0;
 
     &:hover:not(:disabled) {
       .event-icon {


### PR DESCRIPTION
closes #578 