### PR TITLE
Mobile improvements

### DIFF
--- a/assets/chat/css/style.scss
+++ b/assets/chat/css/style.scss
@@ -113,6 +113,14 @@ hr {
   fill: a.$color-surface-dark4;
 }
 
+/* Mobile viewports only */
+@media only screen and (max-width: 450px) {
+  input,
+  textarea {
+    font-size: 16px;
+  }
+}
+
 /* Small screen, non-retina */
 @media only screen and (min-width: 320px) {
   body:not(.pref-fontscale) {

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -406,9 +406,15 @@ class Chat {
         e.preventDefault();
         e.stopPropagation();
         this.control.emit('SEND', this.input.val().toString().trim());
+        this.input[0].inputMode = 'none';
         this.adjustInputHeight();
         this.input.focus();
       }
+    });
+
+    this.input.on('click', () => {
+      this.input[0].inputMode = 'text';
+      this.adjustInputHeight();
     });
 
     // Watching focus
@@ -428,6 +434,7 @@ class Chat {
         downinoutput = false;
         ChatMenu.closeMenus(this);
         this.focusIfNothingSelected();
+        this.input[0].inputMode = 'none';
       }
     });
     this.ui.on('click', '#chat-tools-wrap', () => {

--- a/assets/chat/js/menus/ChatEmoteMenu.js
+++ b/assets/chat/js/menus/ChatEmoteMenu.js
@@ -26,12 +26,22 @@ export default class ChatEmoteMenu extends ChatMenu {
         { atBegin: false },
       ),
     );
+    this.searchinput.on('click', () => {
+      this.searchinput[0].inputMode = 'text';
+    });
   }
 
   show() {
     super.show();
     this.searchinput.focus();
     this.buildEmoteMenu();
+  }
+
+  hide() {
+    if (this.visible) {
+      this.searchinput[0].inputMode = 'none';
+    }
+    super.hide();
   }
 
   buildEmoteMenu() {

--- a/assets/chat/js/menus/ChatUserMenu.js
+++ b/assets/chat/js/menus/ChatUserMenu.js
@@ -88,11 +88,21 @@ export default class ChatUserMenu extends ChatMenu {
         { atBegin: false },
       ),
     );
+    this.searchinput.on('click', () => {
+      this.searchinput[0].inputMode = 'text';
+    });
   }
 
   show() {
     super.show();
     this.searchinput.focus();
+  }
+
+  hide() {
+    if (this.visible) {
+      this.searchinput[0].inputMode = 'none';
+    }
+    super.hide();
   }
 
   redraw() {

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -40,6 +40,7 @@
         tabindex="1"
         autofocus
         spellcheck
+        inputmode="none"
       ></textarea>
       <a id="chat-input-subonly" class="chat-tool-btn" title="Subonly mode">
         <i class="btn-icon"></i>
@@ -274,6 +275,7 @@
           class="form-control"
           value=""
           placeholder="Username search ..."
+          inputmode="none"
         />
       </div>
     </div>
@@ -391,6 +393,7 @@
           class="form-control"
           value=""
           placeholder="Emote search ..."
+          inputmode="none"
         />
       </div>
     </div>


### PR DESCRIPTION
Note: these changes have only been tested on Safari and Chrome on iOS

To prevent the keyboard from popping up by default I use the `inputmode` attribute which signals to the browser which virtual keyboard to display (eg: `inputmode=numeric` may show the 'keypad' instead of a typical keyboard). Setting this to `none` tells the browser not to display any keyboard. In this case, mobile users will need to tap input fields to show a keyboard. Since desktop users use hardware keyboards they are unaffected. Closes #424 