### PR TITLE
Stop opening virtual keyboard on mobile automatically

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -53,7 +53,6 @@ import makeSafeForRegex, {
   nsfwregex,
   nsflregex,
   linkregex,
-  ismobile,
 } from './regex';
 
 import { HashLinkConverter, MISSING_ARG_ERROR } from './hashlinkconverter';
@@ -111,9 +110,6 @@ class Chat {
     this.regexhighlightself = null;
     this.replyusername = null;
     this.watchingfocus = false;
-
-    // The context the chat is rendered in
-    this.ismobile = ismobile.test(window.navigator.userAgent);
 
     // An interface to tell the chat to do things via chat commands, or via emit
     // e.g. control.emit('CONNECT', 'ws://localhost:9001') is essentially chat.cmdCONNECT('ws://localhost:9001')
@@ -238,6 +234,11 @@ class Chat {
     this.control.on('DIE', () => this.cmdDIE());
     this.control.on('SUICIDE', () => this.cmdDIE());
     this.control.on('BITLY', () => this.cmdDIE());
+  }
+
+  get shouldFocus() {
+    // return true when not in a mobile context
+    return !/\bMobi/.test(window.navigator.userAgent);
   }
 
   setUser(user) {
@@ -486,7 +487,7 @@ class Chat {
     const onresize = () => {
       // If this is a mobile screen, don't close menus.
       // The virtual keyboard triggers a 'resize' event, and menus shouldn't be closed whenever the virtual keyboard is opened
-      if (this.ismobile) {
+      if (this.shouldFocus) {
         return;
       }
 
@@ -502,14 +503,18 @@ class Chat {
     this.windowselect.on('click', '.tab-close', (e) => {
       ChatMenu.closeMenus(this);
       this.removeWindow($(e.currentTarget).parent().data('name').toLowerCase());
-      this.input.focus();
+      if (this.shouldFocus) {
+        this.input.focus();
+      }
       return false;
     });
     this.windowselect.on('click', '.tab', (e) => {
       ChatMenu.closeMenus(this);
       this.windowToFront($(e.currentTarget).data('name').toLowerCase());
       this.menus.get('whisper-users').redraw();
-      this.input.focus();
+      if (this.shouldFocus) {
+        this.input.focus();
+      }
       return false;
     });
 
@@ -1019,7 +1024,7 @@ class Chat {
 
   focusIfNothingSelected() {
     // If this is a mobile screen, return to avoid focusing input and bringing up the virtual keyboard
-    if (this.ismobile) {
+    if (this.shouldFocus) {
       return;
     }
 
@@ -2542,7 +2547,9 @@ class Chat {
       }
       this.windowToFront(normalized);
       this.menus.get('whisper-users').redraw();
-      this.input.focus();
+      if (this.shouldFocus) {
+        this.input.focus();
+      }
     }
   }
 

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -53,6 +53,7 @@ import makeSafeForRegex, {
   nsfwregex,
   nsflregex,
   linkregex,
+  ismobile,
 } from './regex';
 
 import { HashLinkConverter, MISSING_ARG_ERROR } from './hashlinkconverter';
@@ -110,6 +111,9 @@ class Chat {
     this.regexhighlightself = null;
     this.replyusername = null;
     this.watchingfocus = false;
+
+    // The context the chat is rendered in
+    this.ismobile = ismobile.test(window.navigator.userAgent);
 
     // An interface to tell the chat to do things via chat commands, or via emit
     // e.g. control.emit('CONNECT', 'ws://localhost:9001') is essentially chat.cmdCONNECT('ws://localhost:9001')
@@ -482,7 +486,7 @@ class Chat {
     const onresize = () => {
       // If this is a mobile screen, don't close menus.
       // The virtual keyboard triggers a 'resize' event, and menus shouldn't be closed whenever the virtual keyboard is opened
-      if (window.screen.width <= 768) {
+      if (this.ismobile) {
         return;
       }
 
@@ -1015,7 +1019,7 @@ class Chat {
 
   focusIfNothingSelected() {
     // If this is a mobile screen, return to avoid focusing input and bringing up the virtual keyboard
-    if (window.screen.width <= 768) {
+    if (this.ismobile) {
       return;
     }
 

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -485,12 +485,6 @@ class Chat {
       { atBegin: false },
     );
     const onresize = () => {
-      // If this is a mobile screen, don't close menus.
-      // The virtual keyboard triggers a 'resize' event, and menus shouldn't be closed whenever the virtual keyboard is opened
-      if (this.shouldFocus) {
-        return;
-      }
-
       if (!resizing) {
         resizing = true;
         ChatMenu.closeMenus(this);
@@ -1023,8 +1017,7 @@ class Chat {
   }
 
   focusIfNothingSelected() {
-    // If this is a mobile screen, return to avoid focusing input and bringing up the virtual keyboard
-    if (this.shouldFocus) {
+    if (!this.shouldFocus) {
       return;
     }
 

--- a/assets/chat/js/menus/ChatEmoteMenu.js
+++ b/assets/chat/js/menus/ChatEmoteMenu.js
@@ -30,7 +30,9 @@ export default class ChatEmoteMenu extends ChatMenu {
 
   show() {
     super.show();
-    this.searchinput.focus();
+    if (!this.ismobile) {
+      this.searchinput.focus();
+    }
     this.buildEmoteMenu();
   }
 

--- a/assets/chat/js/menus/ChatEmoteMenu.js
+++ b/assets/chat/js/menus/ChatEmoteMenu.js
@@ -30,7 +30,7 @@ export default class ChatEmoteMenu extends ChatMenu {
 
   show() {
     super.show();
-    if (!this.ismobile) {
+    if (!this.chat.ismobile) {
       this.searchinput.focus();
     }
     this.buildEmoteMenu();

--- a/assets/chat/js/menus/ChatEmoteMenu.js
+++ b/assets/chat/js/menus/ChatEmoteMenu.js
@@ -30,7 +30,7 @@ export default class ChatEmoteMenu extends ChatMenu {
 
   show() {
     super.show();
-    if (!this.chat.ismobile) {
+    if (this.chat.shouldFocus) {
       this.searchinput.focus();
     }
     this.buildEmoteMenu();
@@ -108,8 +108,9 @@ export default class ChatEmoteMenu extends ChatMenu {
 
   selectEmote(emote) {
     const value = this.chat.input.val().toString().trim();
-    this.chat.input
-      .val(`${value + (value === '' ? '' : ' ') + emote} `)
-      .focus();
+    this.chat.input.val(`${value + (value === '' ? '' : ' ') + emote} `);
+    if (this.chat.shouldFocus) {
+      this.chat.input.focus();
+    }
   }
 }

--- a/assets/chat/js/menus/ChatEmoteTooltip.js
+++ b/assets/chat/js/menus/ChatEmoteTooltip.js
@@ -25,9 +25,10 @@ export default class ChatEmoteTooltip extends ChatMenuFloating {
 
     this.ui.emote.on('click', '.emote', () => {
       const value = this.chat.input.val().toString().trim();
-      this.chat.input
-        .val(`${value + (value === '' ? '' : ' ') + this.emote} `)
-        .focus();
+      this.chat.input.val(`${value + (value === '' ? '' : ' ') + this.emote} `);
+      if (this.chat.shouldFocus) {
+        this.chat.input.focus();
+      }
     });
 
     this.ui.favorite.on('click', () => {

--- a/assets/chat/js/menus/ChatMenu.js
+++ b/assets/chat/js/menus/ChatMenu.js
@@ -1,5 +1,6 @@
 import ChatScrollPlugin from '../scroll';
 import EventEmitter from '../emitter';
+import { ismobile } from '../regex';
 
 export default class ChatMenu extends EventEmitter {
   constructor(ui, btn, chat) {
@@ -14,12 +15,13 @@ export default class ChatMenu extends EventEmitter {
     });
     this.ui.on('click', '.close,.chat-menu-close', this.hide.bind(this));
     this.btn.on('click', (e) => {
-      if (this.visible) {
+      if (this.visible && !this.ismobile) {
         chat.input.focus();
       }
       this.toggle(e);
       return false;
     });
+    this.ismobile = ismobile.test(window.navigator.userAgent);
   }
 
   show() {

--- a/assets/chat/js/menus/ChatMenu.js
+++ b/assets/chat/js/menus/ChatMenu.js
@@ -14,7 +14,7 @@ export default class ChatMenu extends EventEmitter {
     });
     this.ui.on('click', '.close,.chat-menu-close', this.hide.bind(this));
     this.btn.on('click', (e) => {
-      if (this.visible && !this.chat.ismobile) {
+      if (this.visible && this.chat.shouldFocus) {
         chat.input.focus();
       }
       this.toggle(e);

--- a/assets/chat/js/menus/ChatMenu.js
+++ b/assets/chat/js/menus/ChatMenu.js
@@ -1,6 +1,5 @@
 import ChatScrollPlugin from '../scroll';
 import EventEmitter from '../emitter';
-import { ismobile } from '../regex';
 
 export default class ChatMenu extends EventEmitter {
   constructor(ui, btn, chat) {
@@ -15,13 +14,12 @@ export default class ChatMenu extends EventEmitter {
     });
     this.ui.on('click', '.close,.chat-menu-close', this.hide.bind(this));
     this.btn.on('click', (e) => {
-      if (this.visible && !this.ismobile) {
+      if (this.visible && !this.chat.ismobile) {
         chat.input.focus();
       }
       this.toggle(e);
       return false;
     });
-    this.ismobile = ismobile.test(window.navigator.userAgent);
   }
 
   show() {

--- a/assets/chat/js/menus/ChatUserMenu.js
+++ b/assets/chat/js/menus/ChatUserMenu.js
@@ -92,7 +92,7 @@ export default class ChatUserMenu extends ChatMenu {
 
   show() {
     super.show();
-    if (!this.ismobile) {
+    if (!this.chat.ismobile) {
       this.searchinput.focus();
     }
   }

--- a/assets/chat/js/menus/ChatUserMenu.js
+++ b/assets/chat/js/menus/ChatUserMenu.js
@@ -92,7 +92,7 @@ export default class ChatUserMenu extends ChatMenu {
 
   show() {
     super.show();
-    if (!this.chat.ismobile) {
+    if (this.chat.shouldFocus) {
       this.searchinput.focus();
     }
   }

--- a/assets/chat/js/menus/ChatUserMenu.js
+++ b/assets/chat/js/menus/ChatUserMenu.js
@@ -92,7 +92,9 @@ export default class ChatUserMenu extends ChatMenu {
 
   show() {
     super.show();
-    this.searchinput.focus();
+    if (!this.ismobile) {
+      this.searchinput.focus();
+    }
   }
 
   redraw() {

--- a/assets/chat/js/regex.js
+++ b/assets/chat/js/regex.js
@@ -44,9 +44,6 @@ const nickregex = /^\w{3,20}$/;
 const nsfwregex = /\bNSFW\b/i;
 const nsflregex = /\bNSFL\b/i;
 
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_tablet_or_desktop
-const ismobile = /\bMobi/;
-
 export {
   regexslashcmd,
   regextime,
@@ -55,7 +52,6 @@ export {
   nsfwregex,
   nsflregex,
   linkregex,
-  ismobile,
 };
 
 export default function makeSafeForRegex(str) {

--- a/assets/chat/js/regex.js
+++ b/assets/chat/js/regex.js
@@ -45,7 +45,7 @@ const nsfwregex = /\bNSFW\b/i;
 const nsflregex = /\bNSFL\b/i;
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_tablet_or_desktop
-const ismobile = /\bMobi/g;
+const ismobile = /\bMobi/;
 
 export {
   regexslashcmd,

--- a/assets/chat/js/regex.js
+++ b/assets/chat/js/regex.js
@@ -44,6 +44,9 @@ const nickregex = /^\w{3,20}$/;
 const nsfwregex = /\bNSFW\b/i;
 const nsflregex = /\bNSFL\b/i;
 
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_tablet_or_desktop
+const ismobile = /\bMobi/g;
+
 export {
   regexslashcmd,
   regextime,
@@ -52,6 +55,7 @@ export {
   nsfwregex,
   nsflregex,
   linkregex,
+  ismobile,
 };
 
 export default function makeSafeForRegex(str) {


### PR DESCRIPTION
Hilariously small useragent regex courtesy of [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#:~:text=In%20summary%2C%20we%20recommend%20looking%20for%20the%20string%20Mobi%20anywhere%20in%20the%20User%20Agent%20to%20detect%20a%20mobile%20device.).
Otherwise just checking if the chat is in a mobile context before focusing certain input fields.
Issue: #424 