### PR TITLE
feat: add option to choose how to tab-complete in chat

### DIFF
--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -232,6 +232,14 @@ class ChatAutoComplete {
     this.selected = -1;
     this.results = [];
     this.criteria = criteria;
+    const isUserOnly =
+      this.chat.settings.get('autocompletemethod') === '2' ||
+      useronly ||
+      criteria.useronly;
+    const isEmoteOnly =
+      (this.chat.settings.get('autocompletemethod') === '1' || emoteonly) &&
+      !isUserOnly;
+
     if (criteria.word.length >= minWordLength) {
       const bucket = this.buckets.get(getBucketId(criteria.word)) || new Map();
       const regex = new RegExp(`^${makeSafeForRegex(criteria.pre)}`, 'i');
@@ -241,8 +249,8 @@ class ChatAutoComplete {
         // filter users if user search
         .filter(
           (a) =>
-            (!a.isemote || !(criteria.useronly || useronly)) &&
-            (a.isemote || !(criteria.emoteonly || emoteonly)) &&
+            (!a.isemote || !isUserOnly) &&
+            (a.isemote || !isEmoteOnly) &&
             regex.test(a.data),
         )
         .sort(sortResults)

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -228,7 +228,7 @@ class ChatAutoComplete {
     });
   }
 
-  search(criteria, useronly = false) {
+  search(criteria, useronly = false, emoteonly = false) {
     this.selected = -1;
     this.results = [];
     this.criteria = criteria;
@@ -242,6 +242,7 @@ class ChatAutoComplete {
         .filter(
           (a) =>
             (!a.isemote || !(criteria.useronly || useronly)) &&
+            (a.isemote || !(criteria.emoteonly || emoteonly)) &&
             regex.test(a.data),
         )
         .sort(sortResults)

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -140,6 +140,7 @@ const settingsdefault = new Map(
     fontscale: 'auto',
     censorbadwords: false,
     disableanimations: false,
+    autocompletemethod: 0, // 0 = Emotes & Names, 1 = Only Emotes, 2 = Only Names
   }),
 );
 

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -254,6 +254,18 @@
                 Auto-complete helper
               </label>
             </div>
+            <div class="form-group">
+              <label for="autocompletemethod">Autocomplete Method</label>
+              <select
+                class="form-control"
+                id="autocompletemethod"
+                name="autocompletemethod"
+              >
+                <option value="0">Emotes & Names</option>
+                <option value="1">Only Emotes</option>
+                <option value="2">Only Names</option>
+              </select>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
#602 

Adding an option to be able to select how to tab-complete, whether to return:
- Emotes & Names
- Only Emotes
- Only Names

![image](https://github.com/user-attachments/assets/3966908d-a1aa-4c49-b510-e91e1fc11ea5)
