### PR TITLE
fix: dont invert the colors of the donation event bar event

### DIFF
--- a/assets/chat/css/chat/event-bar/_event-bar-event.scss
+++ b/assets/chat/css/chat/event-bar/_event-bar-event.scss
@@ -71,7 +71,6 @@
   @each $amount, $color in donation.$amount-color-map {
     &.amount-#{$amount} {
       border-color: $color;
-      filter: invert(100%);
 
       .event-icon {
         @include a.icon-background('../img/donation-amount-#{$amount}.png');


### PR DESCRIPTION
fixes a regression introduced by me in https://github.com/destinygg/chat-gui/pull/581 (whoops)

without the fix the donation event looks like this :skull: :
![image](https://github.com/user-attachments/assets/ef1cef11-af6d-42c2-bee4-e990f2e3466d)
