### PR TITLE
Implement Discord-like timestamps

### DIFF
--- a/assets/chat/css/messages/_base.scss
+++ b/assets/chat/css/messages/_base.scss
@@ -87,6 +87,12 @@ $link-color-map: (
   .focus & {
     opacity: 0.3;
   }
+
+  .timestamp {
+    background-color: a.$color-surface-dark4;
+    border-radius: 0.25rem;
+    padding: 0.15rem;
+  }
 }
 
 .pref-showtime .time {

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -2,7 +2,8 @@ import { fetch } from 'whatwg-fetch';
 import $ from 'jquery';
 import { debounce } from 'throttle-debounce';
 import moment from 'moment';
-import tippy, { roundArrow } from 'tippy.js';
+import { Application } from '@hotwired/stimulus';
+import { definitionsFromContext } from '@hotwired/stimulus-webpack-helpers';
 import {
   KEYCODES,
   DATE_FORMATS,
@@ -59,6 +60,10 @@ import { HashLinkConverter, MISSING_ARG_ERROR } from './hashlinkconverter';
 import ChatCommands from './commands';
 import MessageTemplateHTML from '../../views/templates.html';
 import EventBarEvent from './event-bar/EventBarEvent';
+
+window.Stimulus = Application.start();
+const context = require.context('./controllers', true, /\.js$/);
+window.Stimulus.load(definitionsFromContext(context));
 
 class Chat {
   constructor(config) {
@@ -304,16 +309,6 @@ class Chat {
       document.getElementsByTagName('head')[0].appendChild(link);
       return link.sheet;
     })();
-
-    // Tooltips
-    tippy.setDefaultProps({ delay: [500, 0] });
-    tippy('[data-tippy-content]', {
-      arrow: roundArrow,
-      duration: 0,
-      maxWidth: 250,
-      hideOnClick: false,
-      theme: 'dgg',
-    });
 
     this.ishidden = (document.visibilityState || 'visible') !== 'visible';
     this.output = this.ui.find('#chat-output-frame');

--- a/assets/chat/js/controllers/relative_timestamp_controller.js
+++ b/assets/chat/js/controllers/relative_timestamp_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from '@hotwired/stimulus';
+import moment from 'moment';
+
+const UPDATE_INTERVAL = 1000;
+
+export default class extends Controller {
+  static values = {
+    timestamp: Number,
+  };
+
+  /** @type moment.Moment */
+  momentTimestamp;
+
+  updateInterval;
+
+  connect() {
+    this.momentTimestamp = moment.unix(this.timestampValue);
+
+    setInterval(() => {
+      this.updateRelativeText();
+    }, UPDATE_INTERVAL);
+  }
+
+  disconnect() {
+    clearInterval(this.updateInterval);
+  }
+
+  updateRelativeText() {
+    const now = moment();
+
+    this.element.textContent = moment
+      .duration(-now.diff(this.momentTimestamp))
+      .humanize(true);
+  }
+}

--- a/assets/chat/js/controllers/tooltip_controller.js
+++ b/assets/chat/js/controllers/tooltip_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from '@hotwired/stimulus';
+import tippy, { roundArrow } from 'tippy.js';
+
+tippy.setDefaultProps({ delay: [500, 0] });
+
+export default class extends Controller {
+  static values = {
+    content: String,
+  };
+
+  connect() {
+    tippy(this.element, {
+      arrow: roundArrow,
+      duration: 0,
+      maxWidth: 250,
+      hideOnClick: false,
+      theme: 'dgg',
+      content: this.contentValue,
+    });
+  }
+}

--- a/assets/chat/js/formatters/TimestampFormatter.js
+++ b/assets/chat/js/formatters/TimestampFormatter.js
@@ -1,0 +1,57 @@
+import moment from 'moment';
+
+const TIMESTAMP_FORMATS = {
+  t12: 'h:mm A',
+  t24: 'HH:mm',
+
+  T12: 'h:mm:ss A',
+  T24: 'HH:mm:ss',
+
+  d12: 'MM/DD/YYYY',
+  d24: 'DD/MM/YYYY',
+
+  D12: 'MMMM DD, YYYY',
+  D24: 'DD MMMM YYYY',
+
+  f12: 'MMMM DD, YYYY [at] h:mm A',
+  f24: 'DD MMMM YYYY [at] HH:mm',
+
+  F12: 'dddd, MMMM DD, YYYY [at] h:mm A Z',
+  F24: 'dddd, DD MMMM YYYY [at] HH:mm Z',
+};
+
+const getBrowserLocale24h = () =>
+  Intl.DateTimeFormat([], { hour: 'numeric' }).resolvedOptions().hour12
+    ? '12'
+    : '24';
+
+export default class TimestampFormatter {
+  constructor() {
+    this.timestampRegex =
+      /&lt;t:(?<timestamp>\d+)(?::(?<type>[tTdDfFR]))?&gt;/g;
+  }
+
+  format(chat, str) {
+    return str.replace(this.timestampRegex, (_, timestamp, type) => {
+      const momentTimestamp = moment.unix(timestamp);
+      const full = momentTimestamp.format(
+        TIMESTAMP_FORMATS[`F${getBrowserLocale24h()}`],
+      );
+
+      if (type === 'R') {
+        const now = moment();
+
+        const relative = moment
+          .duration(-now.diff(momentTimestamp))
+          .humanize(true);
+
+        return `<span class="timestamp" data-controller="relative-timestamp tooltip" data-relative-timestamp-timestamp-value="${timestamp}" data-tooltip-content-value="${full}">${relative}</span>`;
+      }
+
+      const regular = momentTimestamp.format(
+        TIMESTAMP_FORMATS[`${type ?? 'f'}${getBrowserLocale24h()}`],
+      );
+      return `<span class="timestamp" data-controller="tooltip" data-tooltip-content-value="${full}">${regular}</span>`;
+    });
+  }
+}

--- a/assets/chat/js/formatters/index.js
+++ b/assets/chat/js/formatters/index.js
@@ -7,3 +7,4 @@ export { default as EmbedUrlFormatter } from './EmbedUrlFormatter';
 export { default as BadWordsCensorshipFormatter } from './BadWordsCensorshipFormatter';
 export { default as AmazonAssociatesTagInjector } from './AmazonAssociatesTagInjector';
 export { default as SuspostFormatter } from './SuspostFormatter';
+export { default as TimestampFormatter } from './TimestampFormatter';

--- a/assets/chat/js/menus/ChatUserMenu.js
+++ b/assets/chat/js/menus/ChatUserMenu.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import { debounce } from 'throttle-debounce';
-import tippy, { roundArrow } from 'tippy.js';
 import ChatMenu from './ChatMenu';
 import ChatUser from '../user';
 
@@ -250,18 +249,8 @@ export default class ChatUserMenu extends ChatMenu {
     const features =
       user.features.length === 0 ? 'nofeature' : user.features.join(' ');
     const usr = $(
-      `<div class="user-entry" data-username="${user.username}" data-user-id="${user.id}"><span class="user ${features}">${label}</span><div class="user-actions"><i class="whisper-nick" data-tippy-content="Whisper"></i></div></div>`,
+      `<div class="user-entry" data-username="${user.username}" data-user-id="${user.id}"><span class="user ${features}">${label}</span><div class="user-actions"><i class="whisper-nick" data-controller="tooltip" data-tooltip-content-value="Whisper"></i></div></div>`,
     );
-    usr.find('[data-tippy-content]').each(function registerTippy() {
-      tippy(this, {
-        content: this.getAttribute('data-tippy-content'),
-        arrow: roundArrow,
-        duration: 0,
-        maxWidth: 250,
-        hideOnClick: false,
-        theme: 'dgg',
-      });
-    });
     const section = this.sections.get(this.highestSection(user));
 
     if (sort && section.users.children.length > 0) {

--- a/assets/chat/js/messages/ChatMessage.js
+++ b/assets/chat/js/messages/ChatMessage.js
@@ -12,6 +12,7 @@ import {
   BadWordsCensorshipFormatter,
   AmazonAssociatesTagInjector,
   SuspostFormatter,
+  TimestampFormatter,
 } from '../formatters';
 import { DATE_FORMATS } from '../const';
 
@@ -23,6 +24,7 @@ formatters.set('emote', new EmoteFormatter());
 formatters.set('mentioned', new MentionedUserFormatter());
 formatters.set('green', new GreenTextFormatter());
 formatters.set('sus', new SuspostFormatter());
+formatters.set('timestamp', new TimestampFormatter());
 formatters.set('embed', new EmbedUrlFormatter());
 formatters.set('badwordscensor', new BadWordsCensorshipFormatter());
 

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -51,7 +51,8 @@
           id="chat-emoticon-btn"
           class="chat-tool-btn"
           aria-label="Emotes"
-          data-tippy-content="Emotes"
+          data-controller="tooltip"
+          data-tooltip-content-value="Emotes"
         >
           <i class="btn-icon"></i>
         </a>
@@ -59,7 +60,8 @@
           id="chat-whisper-btn"
           class="chat-tool-btn"
           aria-label="Whispers"
-          data-tippy-content="Whispers"
+          data-controller="tooltip"
+          data-tooltip-content-value="Whispers"
         >
           <i class="btn-icon"></i>
         </a>
@@ -68,7 +70,8 @@
         <a
           id="chat-watching-focus-btn"
           class="chat-tool-btn"
-          data-tippy-content="Highlights messages from users watching the same stream"
+          data-controller="tooltip"
+          data-tooltip-content-value="Highlights messages from users watching the same stream"
         >
           <i class="btn-icon"></i>
         </a>
@@ -76,7 +79,8 @@
           id="chat-settings-btn"
           class="chat-tool-btn"
           aria-label="Settings"
-          data-tippy-content="Settings"
+          data-controller="tooltip"
+          data-tooltip-content-value="Settings"
         >
           <i class="btn-icon"></i>
         </a>
@@ -84,7 +88,8 @@
           id="chat-users-btn"
           class="chat-tool-btn"
           aria-label="Users"
-          data-tippy-content="Users"
+          data-controller="tooltip"
+          data-tooltip-content-value="Users"
         >
           <i class="btn-icon"></i>
         </a>
@@ -303,7 +308,8 @@
             id="mute-user-btn"
             class="chat-tool-btn"
             aria-label="Mute"
-            data-tippy-content="Mute"
+            data-controller="tooltip"
+            data-tooltip-content-value="Mute"
           >
             <i class="btn-icon"></i>
           </a>
@@ -311,7 +317,8 @@
             id="ban-user-btn"
             class="chat-tool-btn"
             aria-label="IP Ban"
-            data-tippy-content="IP Ban"
+            data-controller="tooltip"
+            data-tooltip-content-value="IP Ban"
           >
             <i class="btn-icon"></i>
           </a>
@@ -319,7 +326,8 @@
             id="logs-user-btn"
             class="chat-tool-btn"
             aria-label="Stalk"
-            data-tippy-content="Stalk"
+            data-controller="tooltip"
+            data-tooltip-content-value="Stalk"
           >
             <i class="btn-icon"></i>
           </a>
@@ -327,7 +335,8 @@
             id="whisper-user-btn"
             class="chat-tool-btn"
             aria-label="Whisper"
-            data-tippy-content="Whisper"
+            data-controller="tooltip"
+            data-tooltip-content-value="Whisper"
           >
             <i class="btn-icon"></i>
           </a>
@@ -335,7 +344,8 @@
             id="ignore-user-btn"
             class="chat-tool-btn"
             aria-label="Ignore"
-            data-tippy-content="Ignore"
+            data-controller="tooltip"
+            data-tooltip-content-value="Ignore"
           >
             <i class="btn-icon"></i>
           </a>
@@ -343,7 +353,8 @@
             id="unignore-user-btn"
             class="chat-tool-btn"
             aria-label="Unignore"
-            data-tippy-content="Unignore"
+            data-controller="tooltip"
+            data-tooltip-content-value="Unignore"
           >
             <i class="btn-icon"></i>
           </a>
@@ -351,7 +362,8 @@
             id="rustle-user-btn"
             class="chat-tool-btn"
             aria-label="Open Logs"
-            data-tippy-content="Open Logs on RustleSearch"
+            data-controller="tooltip"
+            data-tooltip-content-value="Open Logs on RustleSearch"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "2.53.0",
       "license": "SEE LICENSE IN <LICENSE.md>",
       "dependencies": {
+        "@hotwired/stimulus": "^3.2.2",
+        "@hotwired/stimulus-webpack-helpers": "^1.0.1",
         "dotenv": "^16.0.3",
         "jquery": "^3.6.0",
         "md5": "^2.3.0",
@@ -1850,6 +1852,21 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hotwired/stimulus": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
+      "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==",
+      "license": "MIT"
+    },
+    "node_modules/@hotwired/stimulus-webpack-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz",
+      "integrity": "sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@hotwired/stimulus": ">= 3.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -16059,6 +16076,17 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "dev": true
+    },
+    "@hotwired/stimulus": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
+      "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A=="
+    },
+    "@hotwired/stimulus-webpack-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz",
+      "integrity": "sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "assets": "./assets"
   },
   "dependencies": {
+    "@hotwired/stimulus": "^3.2.2",
+    "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "dotenv": "^16.0.3",
     "jquery": "^3.6.0",
     "md5": "^2.3.0",


### PR DESCRIPTION
Adds a message formatter to chat that converts [Discord style timestamps](https://gist.github.com/LeviSnoot/d9147767abeef2f770e9ddcd91eb85aa) into pretty dates in the user's timezone. Useful for scheduling stuff.

24 hour version:
![Screenshot_20250506_191804](https://github.com/user-attachments/assets/efdbdfb4-c8f7-44fd-89c2-d7d24dbf6c1e)

12 hour version:
![Screenshot_20250506_191822](https://github.com/user-attachments/assets/dc0ba6fe-c8c6-4bd0-8c11-0c81e45fb1db)

