### PR TITLE
fix: shrink autocomplete div to content size

### DIFF
--- a/assets/chat/css/chat/_autocomplete.scss
+++ b/assets/chat/css/chat/_autocomplete.scss
@@ -17,6 +17,8 @@
   right: 0;
   overflow: hidden;
   white-space: nowrap;
+  width: max-content;
+  display: inline-block;
 
   &.active {
     opacity: 1;
@@ -29,6 +31,7 @@
     list-style: none;
     padding: 0;
     margin: 0;
+    position: static;
   }
 
   li {


### PR DESCRIPTION
previously, the autocomplete div would extend horizontally across the whole chat window. now, it will be as wide as its content (the autocomplete options), allowing the user to interact with chat elements that were previously behind the div (e.g. select text, hover emotes, click usernames).