### PR TITLE
Don't duplicate favorite emotes across tiers in the emote menu

### DIFF
--- a/assets/chat/js/menus/ChatEmoteMenu.js
+++ b/assets/chat/js/menus/ChatEmoteMenu.js
@@ -53,7 +53,12 @@ export default class ChatEmoteMenu extends ChatMenu {
       const locked =
         tier > this.chat.user.subTier && !this.chat.user.isPrivileged();
       this.emoteMenuContent.append(
-        this.buildEmoteMenuSection(title, emotes, favoriteEmotes, locked),
+        this.buildEmoteMenuSection(
+          title,
+          emotes,
+          favoriteEmotes.filter((fav) => emotes.includes(fav)),
+          locked,
+        ),
       );
     });
 


### PR DESCRIPTION
Before:
<img width="295" height="349" alt="Before" src="https://github.com/user-attachments/assets/ee3e8ada-8169-4dc0-930c-664a6daf09d9" />

After:
<img width="293" height="340" alt="After" src="https://github.com/user-attachments/assets/1b00b4d9-ff1b-4fe7-b767-2bee6ef8c22e" />
