### PR TITLE
Tagging user with existing tag no longer removes tag unless changing colour/note

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -2151,7 +2151,7 @@ class Chat {
       MessageBuilder.error('User must be present in chat to tag.').into(this);
       return;
     }
-    if (this.taggednicks.has(n)) {
+    if (this.taggednicks.has(n) && parts.length === 1) {
       const note = this.taggednotes.has(n) ? this.taggednotes.get(n) : '';
       const color = this.taggednicks.get(n);
       MessageBuilder.info(`${n} (${color}) ${note}`).into(this);
@@ -2164,14 +2164,14 @@ class Chat {
     }
 
     let color = '';
-    let note = '';
+    let note = this.taggednotes.has(n) ? this.taggednotes.get(n) : '';
     if (parts[1]) {
       if (tagcolors.indexOf(parts[1].toLowerCase()) !== -1) {
         color = parts[1].toLowerCase();
-        note = parts[2] ? parts.slice(2, parts.length).join(' ') : '';
+        note = parts[2] ? parts.slice(2, parts.length).join(' ') : note;
       } else {
         color = tagcolors[Math.floor(Math.random() * tagcolors.length)];
-        note = parts[1] ? parts.slice(1, parts.length).join(' ') : '';
+        note = parts[1] ? parts.slice(1, parts.length).join(' ') : note;
       }
       if (note.length > 100) {
         note = note.substr(0, 100);


### PR DESCRIPTION
Currently if you run
`/tag <username>`
it will overwrite their existing tag colour and note.
This should be changed to instead print the existing tag, similarly to
`/tag`

If the user is not tagged yet, it will behave the same way as it currently does, giving them a randomly coloured tag. 