### PR TITLE
feat: linkify kick-vod hash URLs

### DIFF
--- a/assets/chat/js/formatters/EmbedUrlFormatter.js
+++ b/assets/chat/js/formatters/EmbedUrlFormatter.js
@@ -3,7 +3,7 @@ import { nsflregex, nsfwregex, spoilersregex } from '../regex';
 export default class EmbedUrlFormatter {
   constructor() {
     this.bigscreenregex =
-      /(^|\s)(#(kick|twitch|twitch-vod|twitch-clip|youtube|youtube-live|facebook|rumble|vimeo)\/([\w\d]{3,64}\/videos\/\d{10,20}|[\w-]{3,64}|\w{7}\/\?pub=\w{5})(?:\?t=(\d+)s?)?)\b/g;
+      /(^|\s)(#(kick|kick-vod|twitch|twitch-vod|twitch-clip|youtube|youtube-live|facebook|rumble|vimeo)\/([\w\d]{3,64}\/videos\/\d{10,20}|[\w-]{3,64}\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|[\w-]{3,64}|\w{7}\/\?pub=\w{5})(?:\?t=(\d+)s?)?)\b/g;
   }
 
   format(chat, str /* , message=null */) {

--- a/assets/chat/js/hashlinkconverter.js
+++ b/assets/chat/js/hashlinkconverter.js
@@ -11,6 +11,8 @@ class HashLinkConverter {
     this.twitchClipRegex = /^[^/]+\/clip\/([A-Za-z0-9-_]*)$/;
     this.twitchVODRegex = /^videos\/(\d+)$/;
     this.rumbleEmbedRegex = /^embed\/([a-z0-9]+)\/?$/;
+    this.kickVODRegex =
+      /^([\w-]+)\/videos\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/;
   }
 
   convert(urlString) {
@@ -65,8 +67,12 @@ class HashLinkConverter {
         throw new Error(RUMBLE_EMBED_ERROR);
       case 'www.kick.com':
       case 'kick.com':
-        if (url.searchParams.has('clip') || pathname.startsWith('video/')) {
+        if (url.searchParams.has('clip')) {
           throw new Error(INVALID_LINK_ERROR);
+        }
+        match = pathname.match(this.kickVODRegex);
+        if (match) {
+          return `#kick-vod/${match[1]}/${match[2]}`;
         }
         return `#kick/${pathname}`;
       default:

--- a/assets/chat/js/hashlinkconverter.test.js
+++ b/assets/chat/js/hashlinkconverter.test.js
@@ -85,6 +85,11 @@ describe('Valid embeds', () => {
       '#rumble/v26pcdc',
     ],
     ['Kick stream link', 'https://kick.com/destiny', '#kick/destiny'],
+    [
+      'Kick VOD link',
+      'https://kick.com/destiny/videos/e0829d59-8b57-4266-8f29-003543e339f3',
+      '#kick-vod/destiny/e0829d59-8b57-4266-8f29-003543e339f3',
+    ],
   ])('%s', (_, url, expectedHashLink) => {
     const hlc = new HashLinkConverter();
     expect(hlc.convert(url)).toBe(expectedHashLink);
@@ -103,11 +108,6 @@ describe('Invalid embeds', () => {
       'Youtube link missing video id parameter',
       'https://www.youtube.com/tZ_gn0E87Qo',
       MISSING_VIDEO_ID_ERROR,
-    ],
-    [
-      'Kick VOD link',
-      'https://kick.com/video/d353657d-f6c5-40c0-9df2-645aadda1e66',
-      INVALID_LINK_ERROR,
     ],
     [
       'Kick clip link',


### PR DESCRIPTION
## Summary
- Add `#kick-vod/channel/UUID` hash link support so users can type e.g. `#kick-vod/destiny/fad8876a-4c8a-4491-8ff8-8c4a87dad44e` and have it linkified in chat
- Convert `kick.com/channel/videos/UUID` URLs to `#kick-vod/channel/UUID` format via the hash link converter
- Remove outdated `video/` path rejection that blocked a non-existent old URL format

## Test plan
- [x] `npm test` passes (224 tests)
- [x] Verify `#kick-vod/destiny/fad8876a-4c8a-4491-8ff8-8c4a87dad44e` renders as a clickable link in chat
- [x] Verify pasting `https://kick.com/destiny/videos/e0829d59-8b57-4266-8f29-003543e339f3` converts to `#kick-vod/destiny/e0829d59-8b57-4266-8f29-003543e339f3`