### PR TITLE
Fix user info menu button bar overflow

### DIFF
--- a/assets/chat/css/menus/_user-info.scss
+++ b/assets/chat/css/menus/_user-info.scss
@@ -76,8 +76,8 @@ $toolbar-icons-map: (
 
 .action-buttons {
   margin: a.$gutter-md 0 a.$gutter-md 0;
-  display: grid;
-  grid-auto-flow: column;
+  display: flex;
+  flex-wrap: wrap;
   justify-content: space-around;
 }
 


### PR DESCRIPTION
## Summary
- The action buttons in the user info popup used `grid-auto-flow: column`, forcing all buttons into a single row that overflowed outside the popup when many buttons were visible.
- Changed to `flex-wrap: wrap` so buttons wrap to a second row when they don't fit within the popup's width.

## Test plan
- [x] Open the user info popup on a narrow viewport or with many action buttons visible (e.g., as a moderator)
- [x] Verify buttons wrap within the popup instead of overflowing