### PR TITLE
feat: tier-based subscriber only mode

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -84,7 +84,7 @@ class Chat {
     this.loginscrn = null;
     this.loadingscrn = null;
     this.showmotd = true;
-    this.subonly = false;
+    this.subonly = 0;
     this.authenticated = false;
     this.backlogloading = false;
     this.unresolved = [];
@@ -1437,6 +1437,14 @@ class Chat {
         message = new ChatMessage(messageText, null, MessageTypes.ERROR, true);
         break;
       }
+      case 'submode': {
+        const tier = data.tier || 1;
+        const smTierText = tier > 1 ? ` (Tier ${tier}+)` : '';
+        message = MessageBuilder.error(
+          `The channel is currently in subscriber only mode${smTierText}`,
+        );
+        break;
+      }
       case 'bannedphrase': {
         message = MessageBuilder.error(
           `Your message was blocked because it contained this banned phrase: "${data.filtered}".`,
@@ -1458,14 +1466,26 @@ class Chat {
   }
 
   onSUBONLY(data) {
-    this.subonly = data.data === 'on';
+    const isOn = data.data === 'on';
+    this.subonly = isOn ? data.tier || 1 : 0;
+    const tierText = this.subonly > 1 ? ` (Tier ${this.subonly}+)` : '';
     MessageBuilder.command(
-      `Subscriber only mode ${this.subonly ? 'enabled' : 'disabled'}${
+      `Subscriber only mode${tierText} ${isOn ? 'enabled' : 'disabled'}${
         data.nick ? ` by ${data.nick}` : ''
       }.`,
       data.timestamp,
     ).into(this);
-    if (this.subonly && !this.user.isSubscriber()) {
+    if (
+      this.subonly &&
+      !this.user.isPrivileged() &&
+      this.user.subTier < this.subonly
+    ) {
+      this.subonlyicon.attr(
+        'title',
+        this.subonly > 1
+          ? `Subscriber only mode (Tier ${this.subonly}+)`
+          : 'Subscriber only mode',
+      );
       this.subonlyicon.show();
     } else {
       this.subonlyicon.hide();
@@ -2018,11 +2038,18 @@ class Chat {
   }
 
   cmdSUBONLY(parts, command) {
-    if (/on|off/i.test(parts[0])) {
-      this.source.send(command.toUpperCase(), { data: parts[0].toLowerCase() });
+    if (/^off$/i.test(parts[0])) {
+      this.source.send(command.toUpperCase(), { data: 'off' });
+    } else if (/^on$/i.test(parts[0])) {
+      this.source.send(command.toUpperCase(), { data: 'on', tier: 1 });
+    } else if (/^[1-5]$/.test(parts[0])) {
+      this.source.send(command.toUpperCase(), {
+        data: 'on',
+        tier: parseInt(parts[0], 10),
+      });
     } else {
       MessageBuilder.error(
-        `Invalid argument - /${command.toLowerCase()} on | off`,
+        `Invalid argument - /${command.toLowerCase()} on | off | <tier 1-5>`,
       ).into(this);
     }
   }

--- a/assets/chat/js/commands.js
+++ b/assets/chat/js/commands.js
@@ -163,7 +163,8 @@ const CHAT_COMMANDS = [
   },
   {
     name: 'subonly',
-    description: 'Turn the subscribers-only chat mode <on> or <off>.',
+    description:
+      'Set subscriber-only chat mode <on>, <off>, or to a specific <tier> (1-5).',
     admin: true,
   },
   {


### PR DESCRIPTION
## Summary
- Change `this.subonly` state from boolean to number (0=off, 1-5=minimum tier)
- `cmdSUBONLY` now accepts `on`, `off`, or a tier number `1-5`
- `onSUBONLY` displays tier in system message (e.g. "Subscriber only mode (Tier 3+) enabled") and uses `user.subTier` for icon visibility
- `onERR` handles `submode` errors with tier-aware messaging from the backend's new `SubModeError` payload
- Updated `/subonly` command description to reflect new tier argument

## Test plan
- [x] `/subonly on` — sends `{data: "on", tier: 1}`, system message shows "Subscriber only mode enabled"
- [x] `/subonly 3` — sends `{data: "on", tier: 3}`, system message shows "Subscriber only mode (Tier 3+) enabled"
- [x] `/subonly off` — sends `{data: "off"}`, system message shows "Subscriber only mode disabled"
- [x] Subonly icon shows for non-privileged users whose sub tier is below the required tier
- [x] Subonly icon hidden for privileged users (mods, VIPs, admins) regardless of tier
- [x] Error message for blocked chat shows tier info when tier > 1