### PR TITLE
feat: add AngelThump embed support to chat commands

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -2283,7 +2283,7 @@ class Chat {
     } catch (error) {
       MessageBuilder.error(error.message).into(this);
       MessageBuilder.info(
-        'Usage: /embed <link> OR /e <link> (Valid links: Twitch streams, VODs, clips, Youtube, Rumble, Kick streams)',
+        'Usage: /embed <link> OR /e <link> (Valid links: Twitch streams, VODs, clips, Youtube, Rumble, Kick streams, AngelThump streams)',
       ).into(this);
     }
   }
@@ -2307,7 +2307,7 @@ class Chat {
           MessageBuilder.error(error.message).into(this);
         }
         MessageBuilder.info(
-          'Usage: /postembed [<link>] [<message>] (Alias: /pe) (Valid links: Twitch streams, VODs, clips, Youtube, Rumble, Kick streams)',
+          'Usage: /postembed [<link>] [<message>] (Alias: /pe) (Valid links: Twitch streams, VODs, clips, Youtube, Rumble, Kick streams, AngelThump streams)',
         ).into(this);
       }
     }

--- a/assets/chat/js/formatters/EmbedUrlFormatter.js
+++ b/assets/chat/js/formatters/EmbedUrlFormatter.js
@@ -3,7 +3,7 @@ import { nsflregex, nsfwregex, spoilersregex } from '../regex';
 export default class EmbedUrlFormatter {
   constructor() {
     this.bigscreenregex =
-      /(^|\s)(#(kick|kick-vod|twitch|twitch-vod|twitch-clip|youtube|youtube-live|facebook|rumble|vimeo)\/([\w\d]{3,64}\/videos\/\d{10,20}|[\w-]{3,64}\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|[\w-]{3,64}|\w{7}\/\?pub=\w{5})(?:\?t=(\d+)s?)?)\b/g;
+      /(^|\s)(#(kick|kick-vod|twitch|twitch-vod|twitch-clip|youtube|youtube-live|facebook|rumble|vimeo|angelthump)\/([\w\d]{3,64}\/videos\/\d{10,20}|[\w-]{3,64}\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|[\w-]{3,64}|\w{7}\/\?pub=\w{5})(?:\?t=(\d+)s?)?)\b/g;
   }
 
   format(chat, str /* , message=null */) {

--- a/assets/chat/js/hashlinkconverter.js
+++ b/assets/chat/js/hashlinkconverter.js
@@ -65,6 +65,8 @@ class HashLinkConverter {
           return `#rumble/${match[1]}`;
         }
         throw new Error(RUMBLE_EMBED_ERROR);
+      case 'angelthump.com':
+        return `#angelthump/${pathname}`;
       case 'www.kick.com':
       case 'kick.com':
         if (url.searchParams.has('clip')) {

--- a/assets/chat/js/hashlinkconverter.test.js
+++ b/assets/chat/js/hashlinkconverter.test.js
@@ -84,6 +84,11 @@ describe('Valid embeds', () => {
       'https://rumble.com/embed/v26pcdc/?pub=4',
       '#rumble/v26pcdc',
     ],
+    [
+      'AngelThump stream',
+      'https://angelthump.com/harkonnen1',
+      '#angelthump/harkonnen1',
+    ],
     ['Kick stream link', 'https://kick.com/destiny', '#kick/destiny'],
     [
       'Kick VOD link',


### PR DESCRIPTION
## Summary
- Add AngelThump stream URL parsing to `HashLinkConverter` (e.g. `angelthump.com/harkonnen1` → `#angelthump/harkonnen1`)
- Add `angelthump` to the `EmbedUrlFormatter` bigscreen regex so hash links render as clickable embed links in chat
- Update `/embed` and `/postembed` usage messages to mention AngelThump streams

## Test plan
- [x] Existing `hashlinkconverter` tests pass
- [x] New test case for AngelThump stream URL conversion passes
- [x] Verify `/pe angelthump.com/<channel>` posts the correct `#angelthump/<channel>` hash link
- [x] Verify `#angelthump/<channel>` renders as a clickable embed link in chat