### PR TITLE
fix: allow /host command flags before or after the URL

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -2564,7 +2564,7 @@ class Chat {
   }
 
   cmdHOST(_, args) {
-    let url = _[0];
+    let url = args._[0];
     const { displayName, title } = args;
 
     if (


### PR DESCRIPTION
## Summary
- Use `args._[0]` (yargs-parser positional args) instead of `_[0]` (raw space-split tokens) to extract the URL in `/host`, allowing flags like `--title` and `--display-name` to be placed before or after the URL.

## Test plan
- [x] `/host https://example.com` — works as before
- [x] `/host --title "test" https://example.com` — flags before URL now works
- [x] `/host https://example.com --title "test"` — flags after URL still works
- [x] `/host` with no args — still shows error