### PR TITLE
refactor(roles): drop unused USER and SUBSCRIBER entries

### DIFF
--- a/assets/chat/js/roles.js
+++ b/assets/chat/js/roles.js
@@ -1,6 +1,4 @@
 export default {
-  USER: 'USER',
-  SUBSCRIBER: 'SUBSCRIBER',
   ADMIN: 'ADMIN',
   MODERATOR: 'MODERATOR',
   HOST: 'HOST',


### PR DESCRIPTION
## Summary

Removes the unused `USER` and `SUBSCRIBER` entries from the roles enum in `assets/chat/js/roles.js`. These role keys were not referenced anywhere in the chat-gui codebase, leaving the enum with the meaningful, actively-used roles (`ADMIN`, `MODERATOR`, `HOST`, etc.).

## Changes

- Drop `USER: 'USER'` and `SUBSCRIBER: 'SUBSCRIBER'` from the default roles export.

## Test plan

- [x] Verified no remaining references to the removed role keys in the codebase.