### PR TITLE
feat(event-bar): point XPOST @handle link at the user's X profile

### DIFF
--- a/assets/chat/css/messages/event/_xpost.scss
+++ b/assets/chat/css/messages/event/_xpost.scss
@@ -10,4 +10,30 @@
       @include a.icon-background('../img/icon-x-post.svg');
     }
   }
+
+  .event-bottom {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+
+  .event-bottom-action {
+    display: inline-flex;
+    align-items: center;
+    margin-bottom: 0.25rem;
+    padding: 0.25em a.$gutter-md;
+    border-radius: 6px;
+    background-color: #2a2a2a;
+    color: a.$color-chat-text1;
+    text-decoration: none;
+    font-weight: 600;
+    line-height: 1;
+
+    &:hover,
+    &:focus-visible {
+      background-color: #353535;
+      color: a.$color-chat-text1;
+    }
+  }
 }

--- a/assets/chat/js/messages/ChatXPostMessage.js
+++ b/assets/chat/js/messages/ChatXPostMessage.js
@@ -19,11 +19,14 @@ export default class ChatXPostMessage extends ChatEventMessage {
   html(chat = null) {
     const eventTemplate = super.html(chat);
 
-    const link = document.createElement('a');
+    /** @type HTMLAnchorElement */
+    const link = document
+      .querySelector('#user-template')
+      ?.content.cloneNode(true).firstElementChild;
+    link.classList.add('non-chat-user');
     link.href = `https://x.com/${this.handle}`;
     link.target = '_blank';
     link.rel = 'noopener noreferrer';
-    link.className = 'user non-chat-user';
     link.textContent = `@${this.handle}`;
 
     eventTemplate.querySelector('.event-info').append(link, ' posted on X');
@@ -39,12 +42,11 @@ export default class ChatXPostMessage extends ChatEventMessage {
       }
       bottom.append(text);
 
-      const openButton = document.createElement('a');
+      /** @type HTMLAnchorElement */
+      const openButton = document
+        .querySelector('#xpost-link-template')
+        ?.content.cloneNode(true).firstElementChild;
       openButton.href = this.url;
-      openButton.target = '_blank';
-      openButton.rel = 'noopener noreferrer';
-      openButton.className = 'event-bottom-action xpost-link';
-      openButton.textContent = 'View Post on X';
       bottom.append(openButton);
     }
 

--- a/assets/chat/js/messages/ChatXPostMessage.js
+++ b/assets/chat/js/messages/ChatXPostMessage.js
@@ -20,7 +20,7 @@ export default class ChatXPostMessage extends ChatEventMessage {
     const eventTemplate = super.html(chat);
 
     const link = document.createElement('a');
-    link.href = this.url;
+    link.href = `https://x.com/${this.handle}`;
     link.target = '_blank';
     link.rel = 'noopener noreferrer';
     link.className = 'user non-chat-user';

--- a/assets/chat/js/messages/ChatXPostMessage.js
+++ b/assets/chat/js/messages/ChatXPostMessage.js
@@ -30,6 +30,24 @@ export default class ChatXPostMessage extends ChatEventMessage {
 
     eventTemplate.querySelector('.event-icon').classList.add('xpost');
 
+    const bottom = eventTemplate.querySelector('.event-bottom');
+    if (bottom) {
+      const text = document.createElement('span');
+      text.className = 'event-bottom-text';
+      while (bottom.firstChild) {
+        text.append(bottom.firstChild);
+      }
+      bottom.append(text);
+
+      const openButton = document.createElement('a');
+      openButton.href = this.url;
+      openButton.target = '_blank';
+      openButton.rel = 'noopener noreferrer';
+      openButton.className = 'event-bottom-action xpost-link';
+      openButton.textContent = 'View Post on X';
+      bottom.append(openButton);
+    }
+
     const classes = Array.from(eventTemplate.classList);
     const attributes = eventTemplate
       .getAttributeNames()

--- a/assets/views/templates.html
+++ b/assets/views/templates.html
@@ -24,6 +24,15 @@
   <span class="streak-message"></span>
 </template>
 
+<template id="xpost-link-template">
+  <a
+    class="event-bottom-action xpost-link"
+    target="_blank"
+    rel="noopener noreferrer"
+    >View Post on X</a
+  >
+</template>
+
 <template id="event-bar-event-template">
   <div class="event-bar-event">
     <div class="event-contents">


### PR DESCRIPTION
## Summary

- Adds a "View Post on X" button below the post text inside `.event-bottom` of the XPOST event card, with subtle resting/hover styling.
- Repoints the `@handle` link in the same card from the post URL to the user's X profile (`https://x.com/<handle>`), so username → profile and button → specific post matches the standard X convention.

## Test plan

- [x] `npm run lint` from `chat-gui/` is clean.
- [x] In a local build (`npm start`), dispatch an XPOST event through the dev harness; confirm the expanded card renders the new button below the post text and that resting/hover backgrounds read clearly.
- [x] Hover the `@handle` link — status bar should read `https://x.com/<handle>` with no `/status/...` suffix. Click — opens the profile in a new tab.
- [x] Click "View Post on X" — opens `https://x.com/<handle>/status/<postId>` in a new tab.
- [x] End-to-end (optional): `npm link dgg-chat-gui` into `website/` and trigger admin → X → "Test connection"; verify both links resolve correctly against a real broadcast.