### PR TITLE
Show emote previews in the autocomplete helper

### DIFF
--- a/assets/chat/css/chat/_autocomplete.scss
+++ b/assets/chat/css/chat/_autocomplete.scss
@@ -24,36 +24,45 @@
   }
 
   ul {
+    display: inline-flex;
+    align-items: center;
     position: absolute;
     white-space: nowrap;
     list-style: none;
     padding: 0;
     margin: 0;
   }
+}
 
-  li {
-    padding: 0 a.$gutter-sm;
-    cursor: pointer;
-    text-decoration: none;
-    display: inline-block;
-    color: a.$color-chat-text3;
-    background: rgba(a.$color-surface-dark1, 0.75);
+.autocomplete-entry {
+  padding: 0 a.$gutter-sm;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  gap: a.$gutter-sm;
+  color: a.$color-chat-text3;
+  background: rgba(a.$color-surface-dark1, 0.75);
 
-    &:first-child {
-      border-radius: a.$bradius 0 0 0;
-    }
+  &__emote {
+    display: inline-flex;
+    align-items: center;
+    zoom: 0.75;
+  }
 
-    &:last-child {
-      border-radius: 0 a.$bradius 0 0;
-    }
+  &:first-child {
+    border-radius: a.$bradius 0 0 0;
+  }
 
-    &:hover {
-      color: color.adjust(a.$color-chat-text3, $lightness: 20%);
-    }
+  &:last-child {
+    border-radius: 0 a.$bradius 0 0;
+  }
 
-    &.active {
-      color: a.$text-color;
-    }
+  &:hover {
+    color: color.adjust(a.$color-chat-text3, $lightness: 20%);
+  }
+
+  &.active {
+    color: a.$text-color;
   }
 }
 

--- a/assets/chat/js/autocomplete.js
+++ b/assets/chat/js/autocomplete.js
@@ -352,7 +352,13 @@ class ChatAutoComplete {
   buildHelpers() {
     if (this.results.length > 0) {
       this.container[0].innerHTML = this.results
-        .map((res, k) => `<li data-index="${k}">${res.data}</li>`)
+        .map(
+          (res, k) =>
+            `<li data-index="${k}" class="autocomplete-entry">
+              ${res.isemote ? `<div class="autocomplete-entry__emote"><div class="emote ${res.data}">${res.data}</div></div>` : ''}
+              <span class="autocomplete-entry__name">${res.data}</span>
+            </li>`,
+        )
         .join('');
     }
   }


### PR DESCRIPTION
<img width="415" height="199" alt="Screenshot_20260612_142002" src="https://github.com/user-attachments/assets/0a2824c2-d267-4e10-b491-ce404cbd260c" />

Makes it clearer what autocomplete suggestion is an emote and what is a username. Can be toggled in the settings menu (on by default).