### PR TITLE
Add /untagall command to clear all tagged users

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -188,6 +188,7 @@ class Chat {
     this.control.on('CONNECT', (data) => this.cmdCONNECT(data));
     this.control.on('TAG', (data) => this.cmdTAG(data));
     this.control.on('UNTAG', (data) => this.cmdUNTAG(data));
+    this.control.on('UNTAGALL', (data) => this.cmdUNTAGALL(data));
     this.control.on('EMBED', (data) => this.cmdEMBED(data));
     this.control.on('E', (data) => this.cmdEMBED(data));
     this.control.on('POSTEMBED', (data) => this.cmdPOSTEMBED(data));
@@ -2287,6 +2288,40 @@ class Chat {
     this.settings.set('taggednotes', [...this.taggednotes]);
     this.applySettings();
     MessageBuilder.info(`Un-tagged ${n}.`).into(this);
+  }
+
+  cmdUNTAGALL(parts) {
+    const confirmation = parts[0] || null;
+    if (
+      !confirmation ||
+      (confirmation.toLowerCase() !== 'yes' &&
+        confirmation.toLowerCase() !== 'y')
+    ) {
+      MessageBuilder.error(
+        'This command requires confirmation - /untagall yes OR /untagall y',
+      ).into(this);
+    } else {
+      [...this.taggednicks.keys()].forEach((n) => {
+        this.mainwindow
+          .getlines(`.msg-user[data-username="${n}"]`)
+          .forEach((line) => {
+            const classesToRemove = this.removeClasses(
+              'msg-tagged',
+              line.classList.value,
+            );
+            classesToRemove.forEach((className) =>
+              line.classList.remove(className),
+            );
+            line.querySelector('.user').removeAttribute('title');
+          });
+      });
+      this.taggednicks.clear();
+      this.taggednotes.clear();
+      this.settings.set('taggednicks', [...this.taggednicks]);
+      this.settings.set('taggednotes', [...this.taggednotes]);
+      this.applySettings();
+      MessageBuilder.status(`Your tags have been cleared.`).into(this);
+    }
   }
 
   cmdEMBED(parts) {

--- a/assets/chat/js/commands.js
+++ b/assets/chat/js/commands.js
@@ -212,6 +212,10 @@ const CHAT_COMMANDS = [
     name: 'untag',
     description: 'Untag <nick>.',
   },
+  {
+    name: 'untagall',
+    description: 'Untag all your tagged users.',
+  },
 ];
 
 export default class ChatCommands {


### PR DESCRIPTION
What:
Add /untagall command to clear all your tagged users

To Use: 
"/untagall y" or "/untagall yes"
<img width="340" height="27" alt="image" src="https://github.com/user-attachments/assets/7a3da34f-57cd-41aa-9dda-4ed5f7b46d7e" />

Why
Tedious to clear all your tags one by one 

What it is:
- Clears user's list of tagged [nicks]
- Requires confirmation. i.e. `/untagall` results in a warning message that prompts the use of `y` or `yes`. (mirrors behavior of already existing /unignoreall command) 
- Registered in `CHAT_COMMANDS`, so it's included in `/help` and tab-autocomplete.
<img width="271" height="200" alt="image" src="https://github.com/user-attachments/assets/d25520e3-df02-458a-b0e2-9bf46d645dff" />


Feature Functionality Proof: 
https://www.loom.com/share/7d8816d46d084391a005d3e5da799492


Tested in Mock mode. 'npm test' passes.