### PR TITLE
Fix output-escaping XSS in link and poll rendering

### DIFF
--- a/assets/chat/js/formatters/UrlFormatter.js
+++ b/assets/chat/js/formatters/UrlFormatter.js
@@ -4,8 +4,8 @@ import { nsflregex, nsfwregex, spoilersregex } from '../regex';
 
 const MAX_URL_LENGTH = 90;
 
-function escapeAttr(str) {
-  return str
+function escapeHtml(str) {
+  return String(str)
     .replace(/&/g, '&amp;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;')
@@ -60,16 +60,21 @@ export default class UrlFormatter {
         }
 
         const attrs = Object.keys(attributes).reduce(
-          (acc, cur) => `${acc} ${cur}="${attributes[cur]}"`,
+          (acc, cur) => `${acc} ${cur}="${escapeHtml(attributes[cur])}"`,
           '',
         );
+
+        // linkify decodes HTML entities before handing us `attributes` and
+        // `content`, so both can carry raw `"`, `<`, `>` from the original
+        // message and must be re-escaped to prevent HTML/attribute injection.
+        const safeContent = escapeHtml(content);
 
         const embedTarget = chat.isBigscreenEmbed() ? '_top' : '_blank';
         const embedUrl = `${chat.config.dggOrigin}${chat.bigscreenPath}${embedHashLink}`;
 
         return embedHashLink
-          ? `<${tagName}${attrs}>${content}</${tagName}><a target="${embedTarget}" class="embed-button" href="${escapeAttr(embedUrl)}"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-tv-minimal"><path d="M7 21h10"/><rect width="20" height="14" x="2" y="3" rx="2"/></svg></a>`
-          : `<${tagName}${attrs}>${content}</${tagName}>`;
+          ? `<${tagName}${attrs}>${safeContent}</${tagName}><a target="${embedTarget}" class="embed-button" href="${escapeHtml(embedUrl)}"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-tv-minimal"><path d="M7 21h10"/><rect width="20" height="14" x="2" y="3" rx="2"/></svg></a>`
+          : `<${tagName}${attrs}>${safeContent}</${tagName}>`;
       },
     });
   }

--- a/assets/chat/js/formatters/UrlFormatter.test.js
+++ b/assets/chat/js/formatters/UrlFormatter.test.js
@@ -71,3 +71,54 @@ describe('Normalizing URLs', () => {
     ).toBe('https://www.twitch.tv/search?term=vtuber');
   });
 });
+
+describe('Escaping rendered links (XSS prevention)', () => {
+  // Minimal chat stub covering everything UrlFormatter.format() touches.
+  const chat = {
+    settings: new Map(),
+    config: { dggOrigin: 'https://www.destiny.gg' },
+    bigscreenPath: '/bigscreen',
+    isBigscreenEmbed: () => false,
+  };
+
+  // Mirrors how chat renders a message: text is HTML-escaped first, then the
+  // escaped string is passed to UrlFormatter (which runs it through linkify).
+  function htmlEscape(str) {
+    const el = document.createElement('div');
+    el.textContent = str;
+    return el.innerHTML;
+  }
+
+  function render(rawMessage) {
+    return urlFormatter.format(chat, htmlEscape(rawMessage));
+  }
+
+  test('does not let a URL break out of the href attribute', () => {
+    const output = render('http://x.com/"onmouseover=alert(1)//');
+    // The stray double quote must be encoded so it stays inside href=""...
+    expect(output).toContain('&quot;onmouseover=alert(1)//');
+    // ...and must never appear as a bare event-handler attribute.
+    expect(output).not.toMatch(/["']\s+onmouseover=/i);
+  });
+
+  test('does not let link text break out of the anchor element', () => {
+    const output = render('http://x.com/</a><img src=x onerror=alert(1)>');
+    // No real closing tag / injected element may survive in the link text.
+    expect(output).not.toContain('</a><img');
+    expect(output).not.toContain('<img');
+    expect(output).toContain('&lt;img');
+  });
+
+  test('escapes angle brackets injected via link text', () => {
+    const output = render('http://x.com/<svg/onload=alert(1)>');
+    expect(output).not.toContain('<svg');
+    expect(output).toContain('&lt;svg');
+  });
+
+  test('renders a normal URL as a working anchor', () => {
+    const output = render('check http://x.com/page out');
+    expect(output).toContain('<a');
+    expect(output).toContain('href="http://x.com/page"');
+    expect(output).toContain('class="externallink"');
+  });
+});

--- a/assets/chat/js/poll.js
+++ b/assets/chat/js/poll.js
@@ -3,6 +3,7 @@ import { throttle } from 'throttle-debounce';
 import UserFeatures from './features';
 import UserRoles from './roles';
 import { MessageBuilder } from './messages';
+import encodeUrl from './encodeUrl';
 
 const POLL_CONJUNCTION = /\bor\b/i;
 const POLL_INTERROGATIVE = /^(how|why|when|what|where)\b/i;
@@ -53,6 +54,27 @@ function parseQuestionAndTime(rawQuestion) {
   const question = parseQuestion(rawQuestion.replace(POLL_TIME, '').trim());
   question.time = Math.max(POLL_MIN_TIME, Math.min(time, POLL_MAX_TIME));
   return question;
+}
+
+// Poll options are free-form server text that does not pass through the message
+// formatter pipeline, so they must be HTML-escaped before being interpolated
+// into the option markup (used in both an attribute and element content).
+function buildPollOptionHtml(option, index) {
+  const safeOption = encodeUrl(option);
+  return `
+        <div class="opt" title="Vote ${safeOption}">
+          <div class="opt-info">
+            <span class="opt-vote-number">
+              <strong>${index + 1}</strong>
+            </span>
+            <span class="opt-bar-option">${safeOption}</span>
+            <span class="opt-bar-value"></span>
+          </div>
+          <div class="opt-bar">
+            <div class="opt-bar-inner" style="width: 0;"></div>
+          </div>
+        </div>
+      `;
 }
 
 class ChatPoll {
@@ -159,22 +181,7 @@ class ChatPoll {
     this.ui.question.text(this.poll.question);
     this.ui.options.html(
       this.poll.options
-        .map(
-          (option, i) => `
-        <div class="opt" title="Vote ${option}">
-          <div class="opt-info">
-            <span class="opt-vote-number">
-              <strong>${i + 1}</strong>
-            </span>
-            <span class="opt-bar-option">${option}</span>
-            <span class="opt-bar-value"></span>
-          </div>
-          <div class="opt-bar">
-            <div class="opt-bar-inner" style="width: 0;"></div>
-          </div>
-        </div>
-      `,
-        )
+        .map((option, i) => buildPollOptionHtml(option, i))
         .join(''),
     );
 
@@ -296,4 +303,4 @@ class ChatPoll {
   }
 }
 
-export { ChatPoll, parseQuestionAndTime };
+export { ChatPoll, parseQuestionAndTime, buildPollOptionHtml };

--- a/assets/chat/js/poll.test.js
+++ b/assets/chat/js/poll.test.js
@@ -1,0 +1,54 @@
+import { buildPollOptionHtml } from './poll';
+
+/**
+ * Parse an option's rendered HTML into a detached DOM node so we can inspect
+ * how a browser would actually interpret it.
+ * @param {string} html
+ * @return {HTMLElement} the `.opt` element
+ */
+function renderOption(html) {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  return container.querySelector('.opt');
+}
+
+describe('Escaping poll options (XSS prevention)', () => {
+  test('escapes an element-injection payload in option content', () => {
+    const html = buildPollOptionHtml('<img src=x onerror=alert(1)>', 0);
+
+    // The angle brackets must be encoded, so no real element is created...
+    expect(html).toContain('&lt;img');
+    expect(html).not.toContain('<img');
+
+    const opt = renderOption(html);
+    expect(opt.querySelector('img')).toBeNull();
+    // ...and the payload shows up as literal text instead.
+    expect(opt.querySelector('.opt-bar-option').textContent.trim()).toBe(
+      '<img src=x onerror=alert(1)>',
+    );
+  });
+
+  test('does not let an option break out of the title attribute', () => {
+    const opt = renderOption(buildPollOptionHtml('" onmouseover="alert(1)', 0));
+
+    // The stray quote must stay inside title="", never becoming its own attr.
+    expect(opt.getAttribute('onmouseover')).toBeNull();
+    expect(opt.getAttribute('title')).toBe('Vote " onmouseover="alert(1)');
+  });
+
+  test('renders a benign option as text with the correct vote number', () => {
+    const opt = renderOption(buildPollOptionHtml('Yes', 0));
+
+    expect(opt.querySelector('.opt-bar-option').textContent.trim()).toBe('Yes');
+    expect(opt.querySelector('.opt-vote-number').textContent.trim()).toBe('1');
+  });
+
+  test('preserves non-ASCII option text when parsed back', () => {
+    const opt = renderOption(buildPollOptionHtml('Café', 2));
+
+    expect(opt.querySelector('.opt-bar-option').textContent.trim()).toBe(
+      'Café',
+    );
+    expect(opt.querySelector('.opt-vote-number').textContent.trim()).toBe('3');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two XSS vulnerabilities in chat-gui where free-form data reached the DOM without escaping. Both stem from building HTML strings and interpolating untrusted values without encoding.

### 1. Rendered link output — `assets/chat/js/formatters/UrlFormatter.js`
The custom `linkify-html` `render` callback interpolated `attributes` and `content` into anchor markup without escaping. linkify decodes HTML entities *before* invoking the callback, so escaping done upstream by `HtmlTextFormatter` is undone. A URL in a **normal chat message** could:
- break out of the `href` attribute — `http://x.com/"onmouseover=alert(1)//`
- break out of the link text — `http://x.com/</a><img src=x onerror=alert(1)>`

Fixed by escaping every attribute value **and** the link text via `escapeHtml` (matching linkify's own `defaultRender`).

### 2. Poll options — `assets/chat/js/poll.js`
Poll options were rendered via jQuery `.html()` without escaping, in both a `title="Vote ${option}"` attribute and the option's `<span>` text content. Options are free-form text broadcast to **every viewer** on `POLLSTART`, so a poll-starter (ADMIN/BOT/MODERATOR or the `POLLS` role) could inject markup (`<img src=x onerror=...>`, `" onmouseover=`) that executes in all viewers' browsers.

Fixed by escaping options with the existing `encodeUrl()` helper in a new `buildPollOptionHtml()` (same escaping already used for tag-note titles in `ChatUserMessage`). Options are raw server text and do not pass through `HtmlTextFormatter`, so a single escape pass is correct.

## Testing
- Added regression tests covering both attribute- and element-injection vectors (`UrlFormatter.test.js`, `poll.test.js`).
- Full suite: **233 tests pass**; ESLint clean.

## Notes
Scope is intentionally limited to the two reachable issues. An audit also found defense-in-depth spots (emote tooltip, autocomplete, `EmoteFormatter`, username/flair attributes) that are not exploitable today because the server enforces word-only nicks/emote prefixes; these were left out of this PR.