### PR TITLE
feat(user-info-menu): fetch user info from the API + richer right-click behavior

### DIFF
--- a/assets/chat/css/menus/_user-info.scss
+++ b/assets/chat/css/menus/_user-info.scss
@@ -29,6 +29,11 @@ $toolbar-icons-map: (
     border-bottom: 1px solid a.$color-surface-dark4;
   }
 
+  .user-not-found {
+    padding: a.$gutter-lg a.$gutter-md;
+    text-align: center;
+  }
+
   .flairs {
     margin-top: a.$gutter-lg;
     margin-bottom: a.$gutter-lg;

--- a/assets/chat/css/menus/_user-info.scss
+++ b/assets/chat/css/menus/_user-info.scss
@@ -34,6 +34,22 @@ $toolbar-icons-map: (
     text-align: center;
   }
 
+  .user-info-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: a.$gutter-lg a.$gutter-md;
+
+    .loading-icon {
+      width: 2em;
+      height: 2em;
+      display: inline-block;
+      animation: spin 2s linear infinite;
+
+      @include a.icon-background('../img/icon-settings.svg');
+    }
+  }
+
   .flairs {
     margin-top: a.$gutter-lg;
     margin-bottom: a.$gutter-lg;

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -46,7 +46,11 @@ import { isMuteActive, MutedTimer } from './mutedtimer';
 import EmoteService from './emotes';
 import UserFeatures from './features';
 import UserRoles from './roles';
-import { UserMessageService, YouTubeOEmbedService } from './services';
+import {
+  UserInfoService,
+  UserMessageService,
+  YouTubeOEmbedService,
+} from './services';
 import makeSafeForRegex, {
   regextime,
   nickmessageregex,
@@ -93,6 +97,7 @@ class Chat {
     this.flairsMap = new Map();
     this.emoteService = new EmoteService();
     this.userMessageService = new UserMessageService();
+    this.userInfoService = new UserInfoService(this.config.api.base);
     this.youtubeOEmbedService = new YouTubeOEmbedService();
 
     this.user = new ChatUser();

--- a/assets/chat/js/formatters/MentionedUserFormatter.js
+++ b/assets/chat/js/formatters/MentionedUserFormatter.js
@@ -1,14 +1,28 @@
 export default class MentionedUserFormatter {
   format(chat, str, message = null) {
+    // Wrap any @-prefixed token so it's clickable, whether or not the user is
+    // connected (or even exists — the user-info menu resolves it, showing "not
+    // found" when it doesn't). Anchored on start/whitespace/&gt; before the @
+    // (so it never matches inside a URL or email) with a boundary after (so it
+    // never runs into adjacent markup emitted by the url/emote formatters, which
+    // run earlier). The @ is kept outside the span so click/context handlers
+    // read a clean nick.
+    let result = str.replace(
+      /(^|\s|&gt;)@(\w{3,20})(?=$|\s|[.?!,'])/gim,
+      '$1@<span class="chat-user">$2</span>',
+    );
+
+    // Also wrap bare (no-@) mentions of currently-connected users.
     if (message && message.mentioned && message.mentioned.length > 0) {
-      return str.replace(
+      result = result.replace(
         new RegExp(
-          `((?:^|\\s)@?|&gt;)(${message.mentioned.join('|')})(?=$|\\s|[.?!,'])`,
+          `((?:^|\\s)|&gt;)(${message.mentioned.join('|')})(?=$|\\s|[.?!,'])`,
           'igm',
         ),
         `$1<span class="chat-user">$2</span>`,
       );
     }
-    return str;
+
+    return result;
   }
 }

--- a/assets/chat/js/formatters/MentionedUserFormatter.test.js
+++ b/assets/chat/js/formatters/MentionedUserFormatter.test.js
@@ -1,0 +1,71 @@
+import MentionedUserFormatter from './MentionedUserFormatter';
+
+const formatter = new MentionedUserFormatter();
+
+// Mirrors how chat renders a message: text is HTML-escaped first, then the
+// escaped string is passed to the formatter.
+function htmlEscape(str) {
+  const el = document.createElement('div');
+  el.textContent = str;
+  return el.innerHTML;
+}
+
+function render(rawMessage, mentioned = []) {
+  return formatter.format({}, htmlEscape(rawMessage), { mentioned });
+}
+
+describe('MentionedUserFormatter', () => {
+  it('wraps an @token for a user who is not connected', () => {
+    expect(render('hi @josidjfosd')).toBe(
+      'hi @<span class="chat-user">josidjfosd</span>',
+    );
+  });
+
+  it('keeps the @ outside the span', () => {
+    expect(render('@Destiny')).toBe('@<span class="chat-user">Destiny</span>');
+  });
+
+  it('wraps a bare (no-@) mention of a connected user', () => {
+    expect(render('hey Destiny', ['Destiny'])).toBe(
+      'hey <span class="chat-user">Destiny</span>',
+    );
+  });
+
+  it('wraps a connected @mention exactly once', () => {
+    expect(render('yo @Destiny', ['Destiny'])).toBe(
+      'yo @<span class="chat-user">Destiny</span>',
+    );
+  });
+
+  it('keeps trailing punctuation outside the span', () => {
+    expect(render('ping @Nick.')).toBe(
+      'ping @<span class="chat-user">Nick</span>.',
+    );
+  });
+
+  it('does not wrap an email address', () => {
+    expect(render('mail me@example.com please')).toBe(
+      'mail me@example.com please',
+    );
+  });
+
+  it('does not wrap tokens shorter than 3 characters', () => {
+    expect(render('yo @ab')).toBe('yo @ab');
+  });
+
+  it('does not corrupt an existing link or wrap an @handle inside a URL', () => {
+    // Simulates the string the formatter receives after the URL formatter has
+    // already linkified a URL containing an @handle.
+    const input =
+      'see <a class="externallink" href="https://x.com/@dev">https://x.com/@dev</a> @josidjfosd';
+
+    const out = formatter.format({}, input, { mentioned: [] });
+
+    // The in-URL @dev is untouched (href + link text intact)...
+    expect(out).toContain('href="https://x.com/@dev"');
+    expect(out).toContain('>https://x.com/@dev</a>');
+    // ...and only the trailing standalone @token is wrapped.
+    expect(out).toContain('@<span class="chat-user">josidjfosd</span>');
+    expect(out).not.toContain('>dev</span>');
+  });
+});

--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -32,9 +32,10 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     );
     this.noMessageNotice = this.ui.find('.content .no-messages-notice');
 
-    // Sections toggled for the minimal "user not found" view.
+    // Body sections toggled between the loading / loaded / not-found states.
     this.userInfoSection = this.ui.find('.user-info');
     this.actionsSection = this.ui.find('.actions');
+    this.loadingNotice = this.ui.find('.user-info-loading');
     this.notFoundNotice = this.ui.find('.user-not-found');
 
     this.muteUserBtn = this.ui.find('#mute-user-btn');
@@ -100,20 +101,20 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     this.show();
   }
 
-  // Restores the full menu (details + action buttons), undoing a prior
-  // "not found" state. Called on every open before the fetch resolves.
-  resetMenuSections() {
-    this.userInfoSection.toggleClass('hidden', false);
-    this.actionsSection.toggleClass('hidden', false);
-    this.notFoundNotice.toggleClass('hidden', true);
+  // Toggles the menu body between its mutually-exclusive states:
+  //  - 'loading'  : a spinner while the user's data is being fetched
+  //  - 'loaded'   : the full menu (details + action buttons)
+  //  - 'notFound' : the minimal "user not found" notice
+  setMenuBodyState(state) {
+    this.userInfoSection.toggleClass('hidden', state !== 'loaded');
+    this.actionsSection.toggleClass('hidden', state !== 'loaded');
+    this.loadingNotice.toggleClass('hidden', state !== 'loading');
+    this.notFoundNotice.toggleClass('hidden', state !== 'notFound');
   }
 
-  // Collapses the menu to a minimal "user not found" view: just the header
-  // and the notice, with the details and action buttons hidden.
+  // Collapses the menu to a minimal "user not found" view.
   showUserNotFound() {
-    this.userInfoSection.toggleClass('hidden', true);
-    this.actionsSection.toggleClass('hidden', true);
-    this.notFoundNotice.toggleClass('hidden', false);
+    this.setMenuBodyState('notFound');
     this.redraw();
   }
 
@@ -299,9 +300,6 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
   }
 
   addContent(message) {
-    // Start from the full menu, undoing any prior "not found" collapse.
-    this.resetMenuSections();
-
     // Don't display messages if the giftee was clicked in a gift sub event
     // because the message belongs to the gifter.
     this.messageArray =
@@ -338,15 +336,19 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     this.header.text(displayName);
     this.header.addClass(usernameFeatures);
 
-    // Render immediately from the local cache (fast, no flicker); the details
-    // are refreshed from the website API below.
-    this.renderUserDetails(
-      this.chat.users.get(this.clickedNick),
-      usernameFeatures,
-    );
+    // If the user is already cached, render it immediately (no loading flash)
+    // and let the fetch below refresh it. Otherwise show a spinner until the
+    // fetch resolves.
+    const cachedUser = this.chat.users.get(this.clickedNick);
+    if (cachedUser) {
+      this.setMenuBodyState('loaded');
+      this.renderUserDetails(cachedUser, usernameFeatures);
+    } else {
+      this.setMenuBodyState('loading');
+    }
 
     // Fetch authoritative info from the website so the menu is populated even
-    // for users absent from the local cache. Keep the cached render on failure.
+    // for users absent from the local cache.
     const requestedNick = this.clickedNick;
     this.chat.userInfoService
       .getUserInfo(displayName)
@@ -360,13 +362,26 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
           this.showUserNotFound();
           return;
         }
+        this.setMenuBodyState('loaded');
         const fetchedUser = new ChatUser(data);
         this.renderUserDetails(fetchedUser, usernameFeatures);
         this.setActionsVisibility(fetchedUser);
         this.redraw();
       })
       .catch(() => {
-        // Ignore: the cache/DOM-based render already shown remains in place.
+        // Bail if a different user's menu was opened while this was in flight.
+        if (this.clickedNick !== requestedNick) {
+          return;
+        }
+        // Transient failure: drop the loading spinner and show whatever the
+        // cache/DOM gave us rather than spinning forever.
+        this.setMenuBodyState('loaded');
+        this.renderUserDetails(
+          this.chat.users.get(this.clickedNick),
+          usernameFeatures,
+        );
+        this.setActionsVisibility();
+        this.redraw();
       });
 
     this.setMessageHistoryStatus('Loading history...');

--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -47,32 +47,40 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
 
     this.configureButtons();
 
-    this.chat.output.on('contextmenu', '.msg-chat .user', (e) => {
-      // The `tier` class is a sub-tier label styled to match the username
-      // color of the sub (which requires the `user` class). Suppress both
-      // menus — neither one is meaningful on it.
-      if (e.currentTarget.classList.contains('tier')) {
+    this.chat.output.on(
+      'contextmenu',
+      '.msg-chat .user, .msg-chat .chat-user',
+      (e) => {
+        // The `tier` class is a sub-tier label styled to match the username
+        // color of the sub (which requires the `user` class). Suppress both
+        // menus — neither one is meaningful on it.
+        if (e.currentTarget.classList.contains('tier')) {
+          return false;
+        }
+
+        // `non-chat-user` marks user-like references that aren't chat users
+        // (e.g. an X handle on an XPOST event). Skip our menu and let the
+        // browser's native context menu show.
+        if (e.currentTarget.classList.contains('non-chat-user')) {
+          return;
+        }
+
+        const message = $(e.currentTarget).closest('.msg-chat');
+        this.showUser(e, message);
+
+        // gotta return false so that the actual context menu doesn't show up
         return false;
-      }
-
-      // `non-chat-user` marks user-like references that aren't chat users
-      // (e.g. an X handle on an XPOST event). Skip our menu and let the
-      // browser's native context menu show.
-      if (e.currentTarget.classList.contains('non-chat-user')) {
-        return;
-      }
-
-      const message = $(e.currentTarget).closest('.msg-chat');
-      this.showUser(e, message);
-
-      // gotta return false so that the actual context menu doesn't show up
-      return false;
-    });
+      },
+    );
 
     // preventing the window from closing instantly
-    this.chat.output.on('mouseup', '.msg-chat .user', (e) => {
-      e.stopPropagation();
-    });
+    this.chat.output.on(
+      'mouseup',
+      '.msg-chat .user, .msg-chat .chat-user',
+      (e) => {
+        e.stopPropagation();
+      },
+    );
 
     this.chat.source.on('MSG', this.handleNewMessage.bind(this));
   }
@@ -277,12 +285,17 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
         ? [message]
         : [];
 
-    const selectedUser = [...message[0].querySelectorAll('.user')].find(
+    // Match the message author's `.user` link or an in-text `.chat-user`
+    // mention span whose text is the clicked nick. A mention of someone who
+    // isn't the author has no matching `.user`, so guard against no match.
+    const selectedUser = [
+      ...message[0].querySelectorAll('.user, .chat-user'),
+    ].find(
       (user) => user.innerText.toLowerCase() === this.clickedNick.toLowerCase(),
     );
-    const displayName = selectedUser.innerText;
+    const displayName = selectedUser?.innerText ?? this.clickedNick;
     const tagNote = this.chat.taggednotes.get(this.clickedNick);
-    const usernameFeatures = selectedUser.classList.value;
+    const usernameFeatures = selectedUser?.classList.value ?? '';
 
     if (tagNote) {
       this.tagSubheader.style.display = '';

--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -154,7 +154,7 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     });
   }
 
-  setActionsVisibility() {
+  setActionsVisibility(clickedUser = this.chat.users.get(this.clickedNick)) {
     if (this.chat.user.hasModPowers()) {
       this.muteUserBtn.toggleClass('hidden', false);
       this.banUserBtn.toggleClass('hidden', false);
@@ -167,7 +167,6 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     this.banUserBtn.removeClass('active');
     this.muteUserBtn.removeClass('active');
 
-    const clickedUser = this.chat.users.get(this.clickedNick);
     const isBot = clickedUser?.hasFeature(UserFeatures.BOT);
     if (isBot) {
       this.ignoreUserBtn.toggleClass('hidden', true);
@@ -285,29 +284,6 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     const tagNote = this.chat.taggednotes.get(this.clickedNick);
     const usernameFeatures = selectedUser.classList.value;
 
-    const watchingEmbed = this.buildWatchingEmbed(this.clickedNick);
-    if (watchingEmbed !== '') {
-      this.watchingSubheader.style.display = '';
-      this.watchingSubheader.replaceChildren(
-        'Watching: ',
-        $(watchingEmbed).get()[0],
-      );
-    } else {
-      this.watchingSubheader.style.display = 'none';
-      this.watchingSubheader.replaceChildren();
-    }
-
-    const formattedDate = this.buildCreatedDate(this.clickedNick);
-    if (formattedDate) {
-      this.createdDateSubheader.style.display = '';
-      this.createdDateSubheader.replaceChildren('Joined on ', formattedDate);
-    } else {
-      this.createdDateSubheader.style.display = 'none';
-      this.createdDateSubheader.replaceChildren(
-        'Unable to display account creation date',
-      );
-    }
-
     if (tagNote) {
       this.tagSubheader.style.display = '';
       this.tagSubheader.replaceChildren('Tag: ', tagNote);
@@ -316,24 +292,39 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
       this.tagSubheader.replaceChildren();
     }
 
-    const featuresList = this.buildFeatures(this.clickedNick, usernameFeatures);
-    if (featuresList) {
-      this.flairList.toggleClass('hidden', false);
-      this.flairSubheader.style.display = '';
-    } else {
-      this.flairList.toggleClass('hidden', true);
-      this.flairSubheader.style.display = 'none';
-    }
-
     this.header.text('');
     this.header.attr('class', 'username');
     this.messagesContainer.empty();
     this.updateNoMessagesNotice(true);
-    this.flairList.empty();
 
     this.header.text(displayName);
     this.header.addClass(usernameFeatures);
-    this.flairList.append(featuresList);
+
+    // Render immediately from the local cache (fast, no flicker); the details
+    // are refreshed from the website API below.
+    this.renderUserDetails(
+      this.chat.users.get(this.clickedNick),
+      usernameFeatures,
+    );
+
+    // Fetch authoritative info from the website so the menu is populated even
+    // for users absent from the local cache. Keep the cached render on failure.
+    const requestedNick = this.clickedNick;
+    this.chat.userInfoService
+      .getUserInfo(displayName)
+      .then((data) => {
+        // Bail if a different user's menu was opened while this was in flight.
+        if (this.clickedNick !== requestedNick) {
+          return;
+        }
+        const fetchedUser = new ChatUser(data);
+        this.renderUserDetails(fetchedUser, usernameFeatures);
+        this.setActionsVisibility(fetchedUser);
+        this.redraw();
+      })
+      .catch(() => {
+        // Ignore: the cache/DOM-based render already shown remains in place.
+      });
 
     this.setMessageHistoryStatus('Loading history...');
     this.loadMessageHistory(displayName)
@@ -360,8 +351,50 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
       });
   }
 
-  buildWatchingEmbed(nick) {
-    const user = this.chat.users.get(nick);
+  /**
+   * Renders the watching, account-creation date, and flair sections for the
+   * given user. Safe to call repeatedly — e.g. an initial render from the
+   * local cache followed by a refresh from the website API. `user` may be
+   * undefined (an uncached user), in which case flairs fall back to the
+   * clicked message's CSS classes.
+   */
+  renderUserDetails(user, usernameFeatures) {
+    const watchingEmbed = this.buildWatchingEmbed(user);
+    if (watchingEmbed !== '') {
+      this.watchingSubheader.style.display = '';
+      this.watchingSubheader.replaceChildren(
+        'Watching: ',
+        $(watchingEmbed).get()[0],
+      );
+    } else {
+      this.watchingSubheader.style.display = 'none';
+      this.watchingSubheader.replaceChildren();
+    }
+
+    const formattedDate = this.buildCreatedDate(user);
+    if (formattedDate) {
+      this.createdDateSubheader.style.display = '';
+      this.createdDateSubheader.replaceChildren('Joined on ', formattedDate);
+    } else {
+      this.createdDateSubheader.style.display = 'none';
+      this.createdDateSubheader.replaceChildren(
+        'Unable to display account creation date',
+      );
+    }
+
+    const featuresList = this.buildFeatures(user, usernameFeatures);
+    this.flairList.empty();
+    if (featuresList) {
+      this.flairList.toggleClass('hidden', false);
+      this.flairSubheader.style.display = '';
+      this.flairList.append(featuresList);
+    } else {
+      this.flairList.toggleClass('hidden', true);
+      this.flairSubheader.style.display = 'none';
+    }
+  }
+
+  buildWatchingEmbed(user) {
     if (!user?.watching) {
       return '';
     }
@@ -371,8 +404,7 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     return `<a href="${url}" target="${target}">${user.watching.id} on ${user.watching.platform}</a>`;
   }
 
-  buildCreatedDate(nick) {
-    const user = this.chat.users.get(nick.toLowerCase());
+  buildCreatedDate(user) {
     if (!user?.createdDate) {
       return '';
     }
@@ -385,8 +417,7 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     return timeHTML;
   }
 
-  buildFeatures(nick, messageFeatures) {
-    const user = this.chat.users.get(nick);
+  buildFeatures(user, messageFeatures) {
     const messageFeaturesArray = messageFeatures
       .split(' ')
       .filter((e) => e !== 'user' && e !== 'subscriber');

--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -32,6 +32,11 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     );
     this.noMessageNotice = this.ui.find('.content .no-messages-notice');
 
+    // Sections toggled for the minimal "user not found" view.
+    this.userInfoSection = this.ui.find('.user-info');
+    this.actionsSection = this.ui.find('.actions');
+    this.notFoundNotice = this.ui.find('.user-not-found');
+
     this.muteUserBtn = this.ui.find('#mute-user-btn');
     this.banUserBtn = this.ui.find('#ban-user-btn');
     this.logsUserBtn = this.ui.find('#logs-user-btn');
@@ -93,6 +98,23 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
 
     this.position(e);
     this.show();
+  }
+
+  // Restores the full menu (details + action buttons), undoing a prior
+  // "not found" state. Called on every open before the fetch resolves.
+  resetMenuSections() {
+    this.userInfoSection.toggleClass('hidden', false);
+    this.actionsSection.toggleClass('hidden', false);
+    this.notFoundNotice.toggleClass('hidden', true);
+  }
+
+  // Collapses the menu to a minimal "user not found" view: just the header
+  // and the notice, with the details and action buttons hidden.
+  showUserNotFound() {
+    this.userInfoSection.toggleClass('hidden', true);
+    this.actionsSection.toggleClass('hidden', true);
+    this.notFoundNotice.toggleClass('hidden', false);
+    this.redraw();
   }
 
   configureButtons() {
@@ -277,6 +299,9 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
   }
 
   addContent(message) {
+    // Start from the full menu, undoing any prior "not found" collapse.
+    this.resetMenuSections();
+
     // Don't display messages if the giftee was clicked in a gift sub event
     // because the message belongs to the gifter.
     this.messageArray =
@@ -328,6 +353,11 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
       .then((data) => {
         // Bail if a different user's menu was opened while this was in flight.
         if (this.clickedNick !== requestedNick) {
+          return;
+        }
+        // The user doesn't exist — collapse to the minimal "not found" view.
+        if (data === null) {
+          this.showUserNotFound();
           return;
         }
         const fetchedUser = new ChatUser(data);

--- a/assets/chat/js/messages/ChatVestaboardMessage.js
+++ b/assets/chat/js/messages/ChatVestaboardMessage.js
@@ -76,7 +76,6 @@ export default class ChatVestaboardMessage extends ChatEventMessage {
       const submitter = document
         .querySelector('#user-template')
         ?.content.cloneNode(true).firstElementChild;
-      submitter.classList.add('non-chat-user');
       submitter.textContent = this.submitter;
 
       const verb = VESTABOARD_VERBS[this.type] ?? 'is on the Vestaboard';

--- a/assets/chat/js/services/DggApiClient.js
+++ b/assets/chat/js/services/DggApiClient.js
@@ -1,0 +1,64 @@
+// @ts-check
+
+/**
+ * @typedef {Object} WatchingEmbed
+ * @property {string} platform
+ * @property {string} id
+ */
+
+/**
+ * @typedef {Object} UserInfo
+ * @property {?number} id
+ * @property {string} nick
+ * @property {string[]} roles
+ * @property {string[]} features
+ * @property {?string} createdDate
+ * @property {?WatchingEmbed} watching
+ */
+
+/**
+ * @typedef {Object} JsonResponseEnvelope
+ * @property {boolean} success
+ * @property {?string} message
+ * @property {*} data
+ */
+
+/**
+ * Client for the destiny.gg website's first-party JSON API.
+ */
+export default class DggApiClient {
+  /**
+   * @param {string} apiBase The website origin (e.g. 'https://www.destiny.gg').
+   */
+  constructor(apiBase) {
+    this.apiBase = apiBase;
+  }
+
+  /**
+   * Fetches the public user info shown in the user-info menu.
+   *
+   * @param {string} username
+   * @returns {Promise<UserInfo>}
+   * @throws {Error}
+   */
+  async getUserInfo(username) {
+    const apiUrl = new URL('/api/chat/userinfo', this.apiBase);
+    apiUrl.searchParams.set('username', username);
+
+    const response = await fetch(apiUrl.toString());
+
+    let body;
+    try {
+      /** @type {JsonResponseEnvelope} */
+      body = await response.json();
+    } catch (error) {
+      throw new Error('Invalid JSON', { cause: error });
+    }
+
+    if (!body.success) {
+      throw new Error(body.message ?? 'Failed to fetch user info');
+    }
+
+    return body.data;
+  }
+}

--- a/assets/chat/js/services/DggApiClient.js
+++ b/assets/chat/js/services/DggApiClient.js
@@ -35,10 +35,12 @@ export default class DggApiClient {
   }
 
   /**
-   * Fetches the public user info shown in the user-info menu.
+   * Fetches the public user info shown in the user-info menu. Resolves to
+   * `null` when the user does not exist (HTTP 404), so callers can show a
+   * "not found" state; transient failures still reject.
    *
    * @param {string} username
-   * @returns {Promise<UserInfo>}
+   * @returns {Promise<UserInfo|null>}
    * @throws {Error}
    */
   async getUserInfo(username) {
@@ -56,6 +58,11 @@ export default class DggApiClient {
     }
 
     if (!body.success) {
+      // A 404 means the user doesn't exist; distinguish it from transient
+      // failures (which reject) so the menu can show a "not found" state.
+      if (response.status === 404) {
+        return null;
+      }
       throw new Error(body.message ?? 'Failed to fetch user info');
     }
 

--- a/assets/chat/js/services/DggApiClient.test.js
+++ b/assets/chat/js/services/DggApiClient.test.js
@@ -46,13 +46,23 @@ describe('DggApiClient', () => {
       );
     });
 
-    it('should throw with the envelope message when success is false', async () => {
+    it('should resolve to null when the user does not exist (404)', async () => {
       fetchMock.mockResponseOnce(
         JSON.stringify({ success: false, message: 'User not found' }),
+        { status: 404 },
+      );
+
+      await expect(apiClient.getUserInfo('nobody')).resolves.toBeNull();
+    });
+
+    it('should throw on a non-404 failure envelope', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ success: false, message: 'Server error' }),
+        { status: 500 },
       );
 
       await expect(apiClient.getUserInfo('nobody')).rejects.toThrow(
-        'User not found',
+        'Server error',
       );
     });
 

--- a/assets/chat/js/services/DggApiClient.test.js
+++ b/assets/chat/js/services/DggApiClient.test.js
@@ -1,0 +1,67 @@
+// @ts-check
+
+import fetchMock from 'jest-fetch-mock';
+import DggApiClient from './DggApiClient';
+
+describe('DggApiClient', () => {
+  let apiClient;
+
+  beforeEach(() => {
+    apiClient = new DggApiClient('https://www.destiny.gg');
+    fetchMock.resetMocks();
+  });
+
+  describe('getUserInfo', () => {
+    it('should request the userinfo endpoint and return the data payload', async () => {
+      const userInfo = {
+        id: 123,
+        nick: 'Destiny',
+        roles: ['subscriber'],
+        features: ['flair1', 'admin'],
+        createdDate: '2013-01-01T00:00:00+00:00',
+        watching: { platform: 'twitch', id: 'xqc' },
+      };
+
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ success: true, message: null, data: userInfo }),
+      );
+
+      const result = await apiClient.getUserInfo('Destiny');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://www.destiny.gg/api/chat/userinfo?username=Destiny',
+      );
+      expect(result).toEqual(userInfo);
+    });
+
+    it('should encode the username query parameter', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ success: true, data: { nick: 'a b' } }),
+      );
+
+      await apiClient.getUserInfo('a b');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://www.destiny.gg/api/chat/userinfo?username=a+b',
+      );
+    });
+
+    it('should throw with the envelope message when success is false', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ success: false, message: 'User not found' }),
+      );
+
+      await expect(apiClient.getUserInfo('nobody')).rejects.toThrow(
+        'User not found',
+      );
+    });
+
+    it('should throw when the response is invalid JSON', async () => {
+      fetchMock.mockResponseOnce('not json');
+
+      await expect(apiClient.getUserInfo('Destiny')).rejects.toThrow(
+        'Invalid JSON',
+      );
+    });
+  });
+});

--- a/assets/chat/js/services/UserInfoService.js
+++ b/assets/chat/js/services/UserInfoService.js
@@ -1,0 +1,30 @@
+// @ts-check
+
+import DggApiClient from './DggApiClient';
+
+/**
+ * @typedef {import('./DggApiClient').UserInfo} UserInfo
+ */
+
+/**
+ * Fetches per-user info for the user-info menu from the website API, rather
+ * than relying only on the locally-cached chat presence data.
+ */
+export default class UserInfoService {
+  /**
+   * @param {string} apiBase The website origin (e.g. 'https://www.destiny.gg').
+   * @param {DggApiClient} [apiClient]
+   */
+  constructor(apiBase, apiClient) {
+    this.apiClient = apiClient ?? new DggApiClient(apiBase);
+  }
+
+  /**
+   * @param {string} username
+   * @returns {Promise<UserInfo>}
+   * @throws {Error}
+   */
+  async getUserInfo(username) {
+    return this.apiClient.getUserInfo(username);
+  }
+}

--- a/assets/chat/js/services/UserInfoService.js
+++ b/assets/chat/js/services/UserInfoService.js
@@ -21,7 +21,7 @@ export default class UserInfoService {
 
   /**
    * @param {string} username
-   * @returns {Promise<UserInfo>}
+   * @returns {Promise<UserInfo|null>} `null` when the user does not exist.
    * @throws {Error}
    */
   async getUserInfo(username) {

--- a/assets/chat/js/services/UserInfoService.test.js
+++ b/assets/chat/js/services/UserInfoService.test.js
@@ -65,5 +65,11 @@ describe('UserInfoService', () => {
 
       await expect(service.getUserInfo('Destiny')).rejects.toThrow('API error');
     });
+
+    it('should pass through a null result when the user does not exist', async () => {
+      mockApiClient.mockUserInfo = null;
+
+      await expect(service.getUserInfo('nobody')).resolves.toBeNull();
+    });
   });
 });

--- a/assets/chat/js/services/UserInfoService.test.js
+++ b/assets/chat/js/services/UserInfoService.test.js
@@ -1,0 +1,69 @@
+// @ts-check
+
+import UserInfoService from './UserInfoService';
+import DggApiClient from './DggApiClient';
+
+class MockDggApiClient {
+  constructor() {
+    this.getUserInfoCalls = [];
+    this.mockUserInfo = null;
+    this.mockError = null;
+  }
+
+  async getUserInfo(username) {
+    this.getUserInfoCalls.push({ username });
+
+    if (this.mockError) {
+      throw this.mockError;
+    }
+
+    return this.mockUserInfo;
+  }
+}
+
+describe('UserInfoService', () => {
+  let mockApiClient;
+  let service;
+
+  beforeEach(() => {
+    mockApiClient = new MockDggApiClient();
+    service = new UserInfoService('https://www.destiny.gg', mockApiClient);
+  });
+
+  describe('constructor', () => {
+    it('should build a default DggApiClient when none is provided', () => {
+      const defaultService = new UserInfoService('https://www.destiny.gg');
+      expect(defaultService.apiClient).toBeInstanceOf(DggApiClient);
+      expect(defaultService.apiClient.apiBase).toBe('https://www.destiny.gg');
+    });
+
+    it('should use the provided apiClient', () => {
+      expect(service.apiClient).toBe(mockApiClient);
+    });
+  });
+
+  describe('getUserInfo', () => {
+    it('should delegate to the client and return its result', async () => {
+      const userInfo = {
+        id: 123,
+        nick: 'Destiny',
+        roles: [],
+        features: ['flair1'],
+        createdDate: '2013-01-01T00:00:00+00:00',
+        watching: null,
+      };
+      mockApiClient.mockUserInfo = userInfo;
+
+      const result = await service.getUserInfo('Destiny');
+
+      expect(mockApiClient.getUserInfoCalls).toEqual([{ username: 'Destiny' }]);
+      expect(result).toBe(userInfo);
+    });
+
+    it('should propagate errors from the client', async () => {
+      mockApiClient.mockError = new Error('API error');
+
+      await expect(service.getUserInfo('Destiny')).rejects.toThrow('API error');
+    });
+  });
+});

--- a/assets/chat/js/services/index.js
+++ b/assets/chat/js/services/index.js
@@ -1,3 +1,5 @@
+export { default as DggApiClient } from './DggApiClient';
 export { default as RustleSearchApiClient } from './RustleSearchApiClient';
+export { default as UserInfoService } from './UserInfoService';
 export { default as UserMessageService } from './UserMessageService';
 export { default as YouTubeOEmbedService } from './YouTubeOEmbedService';

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -285,6 +285,7 @@
         <h5><span>User Info</span> <i class="chat-menu-close"></i></h5>
       </div>
       <div class="user-not-found hidden">User not found.</div>
+      <div class="user-info-loading hidden"><i class="loading-icon"></i></div>
       <div class="user-info">
         <h5 class="watching-subheader">Watching:</h5>
         <h5 class="date-subheader"></h5>

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -284,6 +284,7 @@
       <div class="toolbar">
         <h5><span>User Info</span> <i class="chat-menu-close"></i></h5>
       </div>
+      <div class="user-not-found hidden">User not found.</div>
       <div class="user-info">
         <h5 class="watching-subheader">Watching:</h5>
         <h5 class="date-subheader"></h5>


### PR DESCRIPTION
## Summary

Makes the chat user-info menu (right-click on a username) fetch its data from the
website's new public user-info endpoint instead of relying only on the in-memory
presence cache, and extends the right-click behavior across more of the UI.

Requires the endpoint added in destinygg/website-private#1284.

## What's included (commit by commit)

- **Fetch user info from the API** — `DggApiClient` + `UserInfoService`, wired
  into `Chat`. The menu renders from the local cache immediately (when available)
  then refreshes from the API, so it's correct even for users not present in chat.
- **Right-click @mentions** — the menu opens on in-text `@Username` mention spans,
  not just message authors.
- **"Not found" view** — a `404` collapses the menu to a minimal "User not found."
  state (no action buttons / history) instead of a sparse panel.
- **Any `@token` is clickable** — any `@name` is wrapped as a clickable mention
  (not just currently-connected users), so it opens the menu (→ data, or "not
  found").
- **Loading spinner** — while the fetch is in flight for an uncached user, the
  menu shows a spinner (cached users still render instantly, no flicker).
- **Vestaboard event names** — right-click now works on Vestaboard/auction leader
  names in event top lines.

## Test plan

- `npx jest` — full suite passes (new tests for the API client/service, the
  mention formatter, and the 404/null path).
- ESLint + Prettier clean.
- Manual (browser): right-click a message author, an `@mention` (connected and
  not), an `@token` for a non-existent user (→ "User not found."), and a
  Vestaboard event name → the menu opens/populates; uncached users show the
  loading spinner.

## Shipping note

chat-gui ships as the `dgg-chat-gui` npm package; after merge it needs a publish
+ `npm upgrade dgg-chat-gui` in the website for the change to reach production.
