### PR TITLE
feat: show bio, gender, and age in the user-info menu

### DIFF
--- a/assets/chat/css/menus/_user-info.scss
+++ b/assets/chat/css/menus/_user-info.scss
@@ -29,6 +29,15 @@ $toolbar-icons-map: (
     border-bottom: 1px solid a.$color-surface-dark4;
   }
 
+  // The bio can be up to 160 characters, so let it wrap onto multiple lines
+  // instead of overflowing the single-line subheader row.
+  .bio-subheader {
+    padding-top: a.$gutter-sm;
+    padding-bottom: a.$gutter-sm;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
   .user-not-found {
     padding: a.$gutter-lg a.$gutter-md;
     text-align: center;

--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -6,6 +6,24 @@ import UserFeatures from '../features';
 import UserRoles from '../roles';
 import ChatMenuFloating from './ChatMenuFloating';
 
+// Display labels for the raw gender/age enum values sent by the user-info API.
+// Unknown values fall back to the raw value so a new server-side case still
+// renders something sensible.
+const GENDER_LABELS = {
+  male: 'Male',
+  female: 'Female',
+  nonbinary: 'Nonbinary',
+};
+
+const AGE_LABELS = {
+  'under-18': 'Under 18',
+  '18-24': '18-24',
+  '25-34': '25-34',
+  '35-44': '35-44',
+  '45-54': '45-54',
+  '55+': '55+',
+};
+
 export default class ChatUserInfoMenu extends ChatMenuFloating {
   constructor(ui, btn, chat) {
     super(ui, btn, chat, ui.find('.toolbar'));
@@ -20,6 +38,12 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     )[0];
 
     this.createdDateSubheader = this.ui.find('.user-info h5.date-subheader')[0];
+
+    this.ageSubheader = this.ui.find('.user-info h5.age-subheader')[0];
+
+    this.genderSubheader = this.ui.find('.user-info h5.gender-subheader')[0];
+
+    this.bioSubheader = this.ui.find('.user-info h5.bio-subheader')[0];
 
     this.tagSubheader = this.ui.find('.user-info h5.tag-subheader')[0];
 
@@ -410,11 +434,12 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
   }
 
   /**
-   * Renders the watching, account-creation date, and flair sections for the
-   * given user. Safe to call repeatedly — e.g. an initial render from the
-   * local cache followed by a refresh from the website API. `user` may be
-   * undefined (an uncached user), in which case flairs fall back to the
-   * clicked message's CSS classes.
+   * Renders the watching, account-creation date, age, gender, bio, and flair
+   * sections for the given user. Safe to call repeatedly — e.g. an initial
+   * render from the local cache followed by a refresh from the website API.
+   * `user` may be undefined (an uncached user), in which case flairs fall back
+   * to the clicked message's CSS classes and the profile rows (age/gender/bio,
+   * which only come from the API) stay hidden.
    */
   renderUserDetails(user, usernameFeatures) {
     const watchingEmbed = this.buildWatchingEmbed(user);
@@ -440,6 +465,19 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
       );
     }
 
+    // Profile fields (from the authoritative fetch; absent on cache-only users).
+    this.renderTextSubheader(
+      this.ageSubheader,
+      'Age: ',
+      user?.age ? (AGE_LABELS[user.age] ?? user.age) : '',
+    );
+    this.renderTextSubheader(
+      this.genderSubheader,
+      'Gender: ',
+      user?.gender ? (GENDER_LABELS[user.gender] ?? user.gender) : '',
+    );
+    this.renderTextSubheader(this.bioSubheader, 'Bio: ', user?.bio ?? '');
+
     const featuresList = this.buildFeatures(user, usernameFeatures);
     this.flairList.empty();
     if (featuresList) {
@@ -449,6 +487,21 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     } else {
       this.flairList.toggleClass('hidden', true);
       this.flairSubheader.style.display = 'none';
+    }
+  }
+
+  /**
+   * Shows a `<h5>` subheader as `{label}{value}` when `value` is non-empty,
+   * otherwise hides it. `value` is rendered as a text node, so user-controlled
+   * content (e.g. a bio) is safe from injection.
+   */
+  renderTextSubheader(element, label, value) {
+    if (value) {
+      element.style.display = '';
+      element.replaceChildren(label, value);
+    } else {
+      element.style.display = 'none';
+      element.replaceChildren();
     }
   }
 

--- a/assets/chat/js/menus/ChatUserInfoMenu.test.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.test.js
@@ -1,0 +1,96 @@
+// @ts-nocheck
+
+// The scroll plugin pulls in a CSS import that jest can't parse, and this menu
+// never uses it in these tests (no `.scrollable` in the fixture). Stub it so the
+// import chain stays JS-only.
+jest.mock('../scroll', () => ({ __esModule: true, default: class {} }));
+
+import $ from 'jquery';
+import ChatUserInfoMenu from './ChatUserInfoMenu';
+import ChatUser from '../user';
+
+// A minimal `.user-info` subtree containing the subheader rows that
+// `renderUserDetails` reads. `.scrollable` is intentionally omitted so the base
+// menu skips building a scroll plugin.
+const MENU_HTML = `
+  <div id="chat-user-info">
+    <div class="toolbar"><span></span></div>
+    <div class="user-info">
+      <h5 class="watching-subheader"></h5>
+      <h5 class="date-subheader"></h5>
+      <h5 class="age-subheader"></h5>
+      <h5 class="gender-subheader"></h5>
+      <h5 class="bio-subheader"></h5>
+      <h5 class="flairs-subheader"></h5>
+      <div class="flairs"></div>
+    </div>
+  </div>`;
+
+function makeMenu() {
+  const ui = $(MENU_HTML);
+  const chat = {
+    output: { on: () => {} },
+    source: { on: () => {} },
+    user: { hasModPowers: () => false },
+    config: { dggOrigin: 'https://www.destiny.gg' },
+    bigscreenPath: '/bigscreen',
+    isBigscreenEmbed: () => false,
+    isDesktop: false,
+    flairsMap: new Map(),
+  };
+  const menu = new ChatUserInfoMenu(ui, $('<div></div>'), chat);
+  return { menu, ui };
+}
+
+describe('ChatUserInfoMenu.renderUserDetails', () => {
+  it('renders age, gender, and bio with mapped labels when set', () => {
+    const { menu, ui } = makeMenu();
+
+    menu.renderUserDetails(
+      new ChatUser({
+        nick: 'Destiny',
+        gender: 'nonbinary',
+        age: '18-24',
+        bio: 'gaming <b>weow</b>',
+      }),
+      '',
+    );
+
+    const age = ui.find('h5.age-subheader')[0];
+    const gender = ui.find('h5.gender-subheader')[0];
+    const bio = ui.find('h5.bio-subheader')[0];
+
+    expect(age.style.display).toBe('');
+    expect(age.textContent).toBe('Age: 18-24');
+    expect(gender.style.display).toBe('');
+    expect(gender.textContent).toBe('Gender: Nonbinary');
+    // Bio is rendered as a text node, so markup is shown literally, not parsed.
+    expect(bio.style.display).toBe('');
+    expect(bio.textContent).toBe('Bio: gaming <b>weow</b>');
+    expect(bio.querySelector('b')).toBeNull();
+  });
+
+  it('hides each row when its field is unset', () => {
+    const { menu, ui } = makeMenu();
+
+    menu.renderUserDetails(new ChatUser({ nick: 'Blank' }), '');
+
+    expect(ui.find('h5.age-subheader')[0].style.display).toBe('none');
+    expect(ui.find('h5.gender-subheader')[0].style.display).toBe('none');
+    expect(ui.find('h5.bio-subheader')[0].style.display).toBe('none');
+  });
+
+  it('falls back to the raw value for an unknown gender/age', () => {
+    const { menu, ui } = makeMenu();
+
+    menu.renderUserDetails(
+      new ChatUser({ nick: 'Future', gender: 'agender', age: '65+' }),
+      '',
+    );
+
+    expect(ui.find('h5.gender-subheader')[0].textContent).toBe(
+      'Gender: agender',
+    );
+    expect(ui.find('h5.age-subheader')[0].textContent).toBe('Age: 65+');
+  });
+});

--- a/assets/chat/js/services/DggApiClient.test.js
+++ b/assets/chat/js/services/DggApiClient.test.js
@@ -19,6 +19,9 @@ describe('DggApiClient', () => {
         roles: ['subscriber'],
         features: ['flair1', 'admin'],
         createdDate: '2013-01-01T00:00:00+00:00',
+        bio: 'gaming',
+        gender: 'nonbinary',
+        age: '18-24',
         watching: { platform: 'twitch', id: 'xqc' },
       };
 

--- a/assets/chat/js/user.js
+++ b/assets/chat/js/user.js
@@ -7,6 +7,9 @@ import UserFeature from './features';
  * @property {string} createdDate
  * @property {string[]} features
  * @property {string[]} roles
+ * @property {?string} [bio]
+ * @property {?string} [gender]
+ * @property {?string} [age]
  */
 
 class ChatUser {
@@ -53,6 +56,24 @@ class ChatUser {
   watching = null;
 
   /**
+   * User's profile bio.
+   * @type {?string}
+   */
+  bio = null;
+
+  /**
+   * User's gender as a raw enum value (e.g. 'nonbinary'); mapped to a label for display.
+   * @type {?string}
+   */
+  gender = null;
+
+  /**
+   * User's age range as a raw enum value (e.g. '18-24'); mapped to a label for display.
+   * @type {?string}
+   */
+  age = null;
+
+  /**
    * @param {string|User} user
    */
   constructor(user = '') {
@@ -67,6 +88,9 @@ class ChatUser {
       this.features = user.features || [];
       this.roles = user.roles || [];
       this.watching = user.watching || null;
+      this.bio = user.bio ?? null;
+      this.gender = user.gender ?? null;
+      this.age = user.age ?? null;
     }
   }
 

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -289,6 +289,9 @@
       <div class="user-info">
         <h5 class="watching-subheader">Watching:</h5>
         <h5 class="date-subheader"></h5>
+        <h5 class="age-subheader"></h5>
+        <h5 class="gender-subheader"></h5>
+        <h5 class="bio-subheader"></h5>
         <h5 class="tag-subheader"></h5>
         <h5 class="flairs-subheader">Flairs:</h5>
         <div class="flairs"></div>


### PR DESCRIPTION
## What

Renders the three profile fields — **bio**, **gender**, and **age** — as new rows in the chat user-info menu (the popup shown when you click a username).

## How

- `embed.html` — three new `<h5>` subheader rows inside `.user-info`.
- `user.js` — the `ChatUser` model reads `bio`/`gender`/`age` from the API payload.
- `ChatUserInfoMenu.js` — `GENDER_LABELS`/`AGE_LABELS` maps convert the raw enum values from the API to display labels (with a raw-value fallback for unknown cases), plus a small `renderTextSubheader` helper and render blocks following the existing watching/joined-date pattern. The bio is inserted as a **text node** (safe from injection).
- `_user-info.scss` — `.bio-subheader` wraps the up-to-160-character bio.

Rows hide when their field is unset. Profile fields only arrive from the authoritative API fetch, so they stay hidden for cache-only users until it resolves — consistent with how `renderUserDetails` already re-renders.

## Tests

New `ChatUserInfoMenu.test.js` exercises the real `renderUserDetails` in jsdom (mapped labels, hidden-when-unset, unknown-value fallback, bio-as-text-node). `DggApiClient.test.js` fixture extended. Full suite (260 tests) + lint pass.

## Paired change

Depends on the API change in destinygg/website-private (`feat/chat-userinfo-bio-gender-age`), which adds the fields to `/api/chat/userinfo`. Reaches production after this package is published and the website bumps its `dgg-chat-gui` dependency.