### PR TITLE
Turn the whispers panel into a full conversations list

### DIFF
--- a/assets/chat/css/menus/_whispers-list.scss
+++ b/assets/chat/css/menus/_whispers-list.scss
@@ -1,18 +1,23 @@
 @use '../abstracts/' as a;
 
 #chat-whisper-users {
+  // Leave room for the bottom search field, as the user list does.
+  .scrollable {
+    max-height: calc(100% - 3em);
+  }
+
   .content > ul {
     margin: 0;
     padding: a.$gutter-md 0;
   }
 
+  // Read conversations: hide the empty badge and dim the name.
   .unread-0 {
     .badge {
       display: none;
     }
 
-    .user,
-    .user:hover {
+    .conversation__user {
       color: a.$text-color1;
     }
   }
@@ -21,58 +26,90 @@
     color: a.$text-color1;
     margin: a.$gutter-lg;
   }
+
+  #chat-whisper-search input {
+    padding: a.$gutter-lg a.$gutter-lg;
+    border: none;
+    background: none;
+    border-radius: 0;
+  }
+
+  .whisper-load-more {
+    padding: a.$gutter-md a.$gutter-lg;
+
+    .chat-load-more-btn {
+      width: 100%;
+      padding: a.$gutter-md;
+      color: a.$text-color1;
+      background: a.$color-surface-dark4;
+      border: none;
+      border-radius: a.$bradius;
+      cursor: pointer;
+
+      &:hover {
+        color: a.$color-chat-text1;
+        background: a.$color-surface-dark2;
+      }
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+    }
+  }
 }
 
 .conversation {
   list-style: none;
   position: relative;
   cursor: pointer;
-  padding-left: a.$gutter-md;
+  padding: a.$gutter-xs a.$gutter-md;
   display: flex;
-  align-items: center;
+  flex-direction: column;
 
-  .user {
-    color: a.$color-accent;
-    display: block;
-
-    &:hover {
-      color: a.$color-accent-light;
-
-      .badge {
-        color: a.$color-chat-text1;
-      }
-    }
+  &:hover {
+    background: a.$color-surface-dark4;
   }
 
-  .badge,
-  .remove {
-    float: right;
-    margin-right: a.$gutter-md;
+  .conversation__header {
+    display: flex;
+    align-items: baseline;
+  }
+
+  .conversation__user {
+    color: a.$color-accent;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &:hover .conversation__user {
+    color: a.$color-accent-light;
+  }
+
+  .conversation__time {
+    flex-shrink: 0;
+    margin: 0 a.$gutter-md;
+    color: a.$text-color1;
+    font-size: 0.8em;
+  }
+
+  .conversation__preview {
+    color: a.$text-color1;
+    font-size: 0.9em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .badge {
+    flex-shrink: 0;
     font-size: 0.8em;
     padding: 0 a.$gutter-md;
     display: inline-block;
     background: a.$color-surface-dark4;
     border-radius: 50%;
-    margin: a.$gutter-xs 0;
     color: a.$color-chat-text2;
-  }
-
-  .remove {
-    opacity: 0.25;
-    display: inline-block;
-    text-decoration: none;
-    text-align: center;
-    line-height: 1.3em;
-    width: 1.3em;
-    height: 1.3em;
-
-    @include a.icon-background('../img/icon-close.svg');
-
-    &:hover {
-      opacity: 1;
-    }
   }
 }

--- a/assets/chat/css/menus/_whispers-list.scss
+++ b/assets/chat/css/menus/_whispers-list.scss
@@ -8,18 +8,7 @@
 
   .content > ul {
     margin: 0;
-    padding: a.$gutter-md 0;
-  }
-
-  // Read conversations: hide the empty badge and dim the name.
-  .unread-0 {
-    .badge {
-      display: none;
-    }
-
-    .conversation__user {
-      color: a.$text-color1;
-    }
+    padding: a.$gutter-sm 0;
   }
 
   .empty {
@@ -36,19 +25,23 @@
 
   .whisper-load-more {
     padding: a.$gutter-md a.$gutter-lg;
+    text-align: center;
 
+    // Matches the .event-bottom-action button rendered in chat event messages.
     .chat-load-more-btn {
-      width: 100%;
-      padding: a.$gutter-md;
-      color: a.$text-color1;
-      background: a.$color-surface-dark4;
+      display: inline-flex;
+      align-items: center;
+      padding: 0.25em a.$gutter-md;
       border: none;
-      border-radius: a.$bradius;
+      border-radius: 6px;
+      background-color: #2a2a2a;
+      color: a.$color-chat-text1;
+      font-weight: 600;
+      line-height: 1;
       cursor: pointer;
 
       &:hover {
-        color: a.$color-chat-text1;
-        background: a.$color-surface-dark2;
+        background-color: #353535;
       }
 
       &:disabled {
@@ -63,35 +56,77 @@
   list-style: none;
   position: relative;
   cursor: pointer;
-  padding: a.$gutter-xs a.$gutter-md;
   display: flex;
-  flex-direction: column;
+  align-items: flex-start;
+  gap: a.$gutter-md;
+  padding: a.$gutter-lg;
 
   &:hover {
     background: a.$color-surface-dark4;
   }
 
+  // Unread indicator: dim grey when nothing new, blue when there is.
+  .conversation__indicator {
+    flex-shrink: 0;
+    width: 0.5em;
+    height: 0.5em;
+    margin-top: 0.4em;
+    border-radius: 50%;
+    background: a.$text-color1;
+    opacity: 0.35;
+  }
+
+  &.conversation--unread .conversation__indicator {
+    background: a.$color-accent;
+    opacity: 1;
+  }
+
+  // min-width: 0 lets the name and preview ellipsis inside the flex row.
+  .conversation__body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: a.$gutter-sm;
+  }
+
   .conversation__header {
     display: flex;
     align-items: baseline;
+    gap: a.$gutter-md;
   }
 
   .conversation__user {
-    color: a.$color-accent;
     flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    color: a.$color-chat-text1;
   }
 
-  &:hover .conversation__user {
-    color: a.$color-accent-light;
+  .conversation__meta {
+    flex-shrink: 0;
+    display: flex;
+    align-items: baseline;
+    gap: a.$gutter-md;
+  }
+
+  // A quiet neutral chip — the blue indicator dot is the eye-catching signal,
+  // not this. Recessed (darker than the row, even on hover) so it stays legible
+  // without drawing attention.
+  .conversation__count {
+    flex-shrink: 0;
+    padding: 0 a.$gutter-md;
+    border-radius: 1em;
+    background: a.$color-surface-dark2;
+    color: a.$color-chat-text2;
+    font-size: 0.75em;
+    font-weight: 600;
   }
 
   .conversation__time {
-    flex-shrink: 0;
-    margin: 0 a.$gutter-md;
-    color: a.$text-color1;
+    color: a.$color-chat-text3;
     font-size: 0.8em;
   }
 
@@ -101,15 +136,5 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  .badge {
-    flex-shrink: 0;
-    font-size: 0.8em;
-    padding: 0 a.$gutter-md;
-    display: inline-block;
-    background: a.$color-surface-dark4;
-    border-radius: 50%;
-    color: a.$color-chat-text2;
   }
 }

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -702,23 +702,36 @@ class Chat {
       .catch(() => {});
   }
 
-  async loadWhispers() {
-    fetch(`${this.config.api.base}/api/messages/unread`, {
+  async loadUnreadCount() {
+    fetch(`${this.config.api.base}/api/messages/unread-count`, {
       credentials: 'include',
     })
       .then((res) => res.json())
       .then((d) => {
-        d.forEach((e) =>
-          this.whispers.set(e.username.toLowerCase(), {
-            id: e.messageid,
-            nick: e.username,
-            unread: Number(e.unread),
-            open: false,
-          }),
-        );
+        this.menus.get('whisper-users').seedUnread(Number(d.count) || 0);
       })
-      .then(() => this.menus.get('whisper-users').redraw())
       .catch(() => {});
+  }
+
+  /**
+   * Ensure a conversation exists in the whispers Map with the full shape the
+   * conversations panel renders. Returns the entry.
+   */
+  ensureConversation(nick) {
+    const normalized = nick.toLowerCase();
+    if (!this.whispers.has(normalized)) {
+      this.whispers.set(normalized, {
+        id: null,
+        nick,
+        username: normalized,
+        unread: 0,
+        open: false,
+        lastMessage: '',
+        timestamp: null,
+        lastMessageFromMe: false,
+      });
+    }
+    return this.whispers.get(normalized);
   }
 
   setPreLoginText() {
@@ -1046,7 +1059,7 @@ class Chat {
             } ${w.visible ? 'active' : ''}"><i class="dgg-icon"></i></span>`,
           );
         } else {
-          const conv = this.whispers.get(w.name);
+          const conv = this.whispers.get(w.name) || { unread: 0 };
           this.windowselect.append(`<span title="${w.label}" data-name="${
             w.name
           }" class="tab win-${w.name} tag-${w.tag} ${
@@ -1235,7 +1248,8 @@ class Chat {
     if (this.authenticated) {
       // If is a logged in user.
       this.loadSettings();
-      this.loadWhispers();
+      this.loadUnreadCount();
+      this.menus.get('whisper-users').invalidate();
       this.refreshEmoteAutocomplete();
     }
   }
@@ -1701,19 +1715,17 @@ class Chat {
   onPRIVMSG(data) {
     const normalized = data.nick.toLowerCase();
     if (!this.ignored(normalized, data.data)) {
-      if (!this.whispers.has(normalized)) {
-        this.whispers.set(normalized, {
-          nick: data.nick,
-          unread: 0,
-          open: false,
-        });
-      }
+      const conv = this.ensureConversation(data.nick);
+      conv.nick = data.nick;
+      conv.lastMessage = data.data;
+      conv.timestamp = data.timestamp;
+      conv.lastMessageFromMe = false;
 
-      const conv = this.whispers.get(normalized);
       const user = this.users.get(normalized) || new ChatUser(data.nick);
       const messageid = Object.hasOwn(data, 'messageid')
         ? data.messageid
         : null;
+      const whisperMenu = this.menus.get('whisper-users');
 
       if (this.settings.get('showhispersinchat')) {
         MessageBuilder.whisper(
@@ -1748,9 +1760,10 @@ class Chat {
         }).catch();
       } else {
         conv.unread += 1;
+        whisperMenu.incrementUnread(1);
       }
       this.replyusername = user.displayName;
-      this.menus.get('whisper-users').redraw();
+      whisperMenu.bumpConversation(normalized);
       this.redrawWindowIndicators();
     }
   }
@@ -1795,6 +1808,7 @@ class Chat {
       else if (win !== this.mainwindow) {
         MessageBuilder.message(raw, this.user).into(this, win);
         this.source.send('PRIVMSG', { nick: win.name, data: raw });
+        this.recordSentWhisper(win.name, raw);
         this.input.val('');
       }
       // VOTE
@@ -2246,7 +2260,21 @@ class Chat {
       const data = parts.slice(1, parts.length).join(' ');
       this.replyusername = parts[0];
       this.source.send('PRIVMSG', { nick: parts[0], data });
+      this.recordSentWhisper(parts[0], data);
     }
+  }
+
+  /**
+   * Record a whisper the user just sent so its conversation shows the latest
+   * message and floats to the top of the list. Never touches the unread badge
+   * — sending does not create unread mail for the sender.
+   */
+  recordSentWhisper(nick, text) {
+    const conv = this.ensureConversation(nick);
+    conv.lastMessage = text;
+    conv.timestamp = Date.now();
+    conv.lastMessageFromMe = true;
+    this.menus.get('whisper-users').bumpConversation(nick.toLowerCase());
   }
 
   cmdCONNECT(parts) {
@@ -2532,13 +2560,7 @@ class Chat {
     if (win != null) {
       this.windowToFront(normalized);
     } else {
-      if (!this.whispers.has(normalized)) {
-        this.whispers.set(normalized, {
-          nick: normalized,
-          unread: 0,
-          open: false,
-        });
-      }
+      this.ensureConversation(normalized);
       this.openConversation(normalized);
     }
   }
@@ -2887,6 +2909,9 @@ class Chat {
             win,
           ),
         );
+      }
+      if (conv.unread > 0) {
+        this.menus.get('whisper-users').decrementUnread(conv.unread);
       }
       conv.unread = 0;
       conv.open = true;

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -708,7 +708,7 @@ class Chat {
     })
       .then((res) => res.json())
       .then((d) => {
-        this.menus.get('whisper-users').seedUnread(Number(d.count) || 0);
+        this.menus.get('whisper-users').seedUnread(Number(d?.data?.count) || 0);
       })
       .catch(() => {});
   }

--- a/assets/chat/js/menus/ChatWhisperUsers.js
+++ b/assets/chat/js/menus/ChatWhisperUsers.js
@@ -5,6 +5,12 @@ import ChatMenu from './ChatMenu';
 import ChatUser from '../user';
 import { DATE_FORMATS } from '../const';
 
+// Unread counts past this render as "99+".
+const MAX_DISPLAY_COUNT = 99;
+function formatCount(n) {
+  return n > MAX_DISPLAY_COUNT ? `${MAX_DISPLAY_COUNT}+` : String(n);
+}
+
 /**
  * The conversations panel: all of the user's DM threads, newest first,
  * cursor-paginated with a "Load more" button and searchable by username.
@@ -85,13 +91,16 @@ export default class ChatWhisperUsers extends ChatMenu {
       setTimeout(() => this.btn.removeClass('ping'), 2000);
     }
     this.prevUnread = this.unread;
-    this.notif.text(this.unread);
+    const shown = formatCount(this.unread);
+    this.notif.text(shown);
     this.notif.toggle(this.unread > 0);
     try {
-      // Mirror the unread total into the parent window title.
-      const t = window.parent.document.title.replace(/\([0-9]+\) /, '');
+      // Mirror the unread total into the parent window title. The strip regex
+      // allows a trailing "+" so a capped "(99+) " prefix is replaced, not
+      // stacked, on the next update.
+      const t = window.parent.document.title.replace(/\([0-9]+\+?\) /, '');
       window.parent.document.title =
-        this.unread > 0 ? `(${this.unread}) ${t}` : `${t}`;
+        this.unread > 0 ? `(${shown}) ${t}` : `${t}`;
     } catch {} // eslint-disable-line no-empty
   }
 
@@ -306,7 +315,7 @@ export default class ChatWhisperUsers extends ChatMenu {
     // New-message count badge, to the left of the last-activity time.
     if (unread > 0) {
       $('<span class="conversation__count"></span>')
-        .text(`${unread} new`)
+        .text(`${formatCount(unread)} new`)
         .appendTo(meta);
     }
     if (conv.timestamp != null) {

--- a/assets/chat/js/menus/ChatWhisperUsers.js
+++ b/assets/chat/js/menus/ChatWhisperUsers.js
@@ -143,7 +143,8 @@ export default class ChatWhisperUsers extends ChatMenu {
       const res = await fetch(this.buildUrl(search, cursor), {
         credentials: 'include',
       });
-      const data = await res.json();
+      // Unwrap the JsonResponse envelope: { success, data: { results, ... } }.
+      const { data } = await res.json();
       return data && Array.isArray(data.results) ? data : empty;
     } catch {
       return empty;

--- a/assets/chat/js/menus/ChatWhisperUsers.js
+++ b/assets/chat/js/menus/ChatWhisperUsers.js
@@ -288,29 +288,39 @@ export default class ChatWhisperUsers extends ChatMenu {
     const user = this.chat.users.get(key) || new ChatUser(conv.nick);
     const unread = conv.unread || 0;
 
-    const row = $(`<li class="conversation unread-${unread}"></li>`).attr(
-      'data-username',
-      user.username,
-    );
-    const header = $('<div class="conversation__header"></div>');
+    const row = $('<li class="conversation"></li>')
+      .toggleClass('conversation--unread', unread > 0)
+      .attr('data-username', user.username);
+
+    // A dot rather than a coloured name signals unread (blue) vs read (grey).
+    $('<span class="conversation__indicator"></span>').appendTo(row);
+
+    const body = $('<div class="conversation__body"></div>').appendTo(row);
+    const header = $('<div class="conversation__header"></div>').appendTo(body);
     // .text() throughout: the preview is arbitrary user-authored message text.
     $('<span class="conversation__user"></span>')
       .text(user.displayName)
       .appendTo(header);
+
+    const meta = $('<span class="conversation__meta"></span>').appendTo(header);
+    // New-message count badge, to the left of the last-activity time.
+    if (unread > 0) {
+      $('<span class="conversation__count"></span>')
+        .text(`${unread} new`)
+        .appendTo(meta);
+    }
     if (conv.timestamp != null) {
       const when = moment(conv.timestamp);
       $('<time class="conversation__time"></time>')
         .attr('datetime', when.toISOString())
         .attr('title', when.format(DATE_FORMATS.FULL))
-        .text(when.fromNow(true))
-        .appendTo(header);
+        .text(when.fromNow())
+        .appendTo(meta);
     }
-    $('<span class="badge"></span>').text(unread).appendTo(header);
-    row.append(header);
 
     const preview =
       (conv.lastMessageFromMe ? 'You: ' : '') + (conv.lastMessage || '');
-    $('<div class="conversation__preview"></div>').text(preview).appendTo(row);
+    $('<div class="conversation__preview"></div>').text(preview).appendTo(body);
 
     return row;
   }

--- a/assets/chat/js/menus/ChatWhisperUsers.js
+++ b/assets/chat/js/menus/ChatWhisperUsers.js
@@ -1,80 +1,353 @@
 import $ from 'jquery';
+import moment from 'moment';
+import { debounce } from 'throttle-debounce';
 import ChatMenu from './ChatMenu';
 import ChatUser from '../user';
+import { DATE_FORMATS } from '../const';
 
+/**
+ * The conversations panel: all of the user's DM threads, newest first,
+ * cursor-paginated with a "Load more" button and searchable by username.
+ *
+ * Data lives in `chat.whispers` (a Map keyed by lowercased username) — the
+ * single store the rest of chat.js reads for window interop. This panel only
+ * owns the *order* of what it shows: `conversations` and `searchResults` are
+ * arrays of keys into that Map, so search mode never disturbs the normal list.
+ * The unread badge is a scalar seeded from a dedicated endpoint, never summed
+ * from the (now partial) list.
+ */
 export default class ChatWhisperUsers extends ChatMenu {
   constructor(ui, btn, chat) {
     super(ui, btn, chat);
+
     this.unread = 0;
-    this.empty = $(`<span class="empty">No new whispers :(</span>`);
+    this.prevUnread = 0;
+
+    this.conversations = [];
+    this.searchResults = [];
+    this.cursor = null;
+    this.searchCursor = null;
+    this.more = false;
+    this.searchMore = false;
+    this.loading = false;
+    this.loaded = false;
+    this.searchterm = '';
+    this.searchSeq = 0;
+
+    this.empty = $(`<span class="empty">No conversations yet</span>`);
     this.notif = $(`<span id="chat-whisper-unread-indicator"></span>`);
     this.btn.append(this.notif);
-    this.usersEl = ui.find('ul:first');
-    this.usersEl.on('click', '.user', (e) =>
-      chat.openConversation(e.target.getAttribute('data-username')),
+
+    this.listEl = ui.find('ul:first');
+    this.loadMoreEl = ui.find('.whisper-load-more');
+    this.searchinput = ui.find('#chat-whisper-search .form-control:first');
+
+    this.listEl.on('click', '.conversation', (e) =>
+      chat.openConversation(e.currentTarget.getAttribute('data-username')),
     );
-    this.usersEl.on('click', '.remove', (e) =>
-      this.removeConversation(e.target.getAttribute('data-username')),
+    this.loadMoreEl.on('click', 'button', () => this.loadMore());
+    this.searchinput.on(
+      'keyup',
+      debounce(
+        250,
+        () => {
+          this.searchterm = this.searchinput.val().toString().trim();
+          this.onSearchChange();
+        },
+        { atBegin: false },
+      ),
     );
   }
 
-  removeConversation(nick) {
-    const normalized = nick.toLowerCase();
-    this.chat.whispers.delete(normalized);
-    this.chat.removeWindow(normalized);
-    this.redraw();
+  show() {
+    super.show();
+    if (this.chat.isDesktop) {
+      this.searchinput.focus();
+    }
+    if (!this.loaded && !this.loading) {
+      this.loadFirstPage();
+    }
   }
+
+  redraw() {
+    this.updateNotification();
+    if (this.visible) {
+      this.renderList();
+    }
+    super.redraw();
+  }
+
+  // --- unread badge (scalar) --------------------------------------------
 
   updateNotification() {
-    const wasunread = this.unread;
-    this.unread = [...this.chat.whispers.entries()]
-      .map((e) => parseInt(e[1].unread, 10))
-      .reduce((a, b) => a + b, 0);
-    if (wasunread < this.unread) {
+    if (this.prevUnread < this.unread) {
       this.btn.addClass('ping');
       setTimeout(() => this.btn.removeClass('ping'), 2000);
     }
+    this.prevUnread = this.unread;
     this.notif.text(this.unread);
     this.notif.toggle(this.unread > 0);
     try {
-      // Add the number of unread items to the window title.
+      // Mirror the unread total into the parent window title.
       const t = window.parent.document.title.replace(/\([0-9]+\) /, '');
       window.parent.document.title =
         this.unread > 0 ? `(${this.unread}) ${t}` : `${t}`;
     } catch {} // eslint-disable-line no-empty
   }
 
-  redraw() {
-    this.updateNotification(); // its always visible
-    if (this.visible) {
-      this.usersEl.empty();
-      if (this.chat.whispers.size === 0) {
-        this.usersEl.append(this.empty);
-      } else {
-        [...this.chat.whispers.entries()]
-          .sort((a, b) => {
-            if (a[1].unread === 0) {
-              return 1;
-            }
-            if (b[1].unread === 0) {
-              return -1;
-            }
-            return 0;
-          })
-          .forEach((e) => this.addConversation(e[0], e[1].unread));
-      }
-    }
-    super.redraw();
+  seedUnread(count) {
+    this.unread = Math.max(0, count | 0);
+    this.updateNotification();
   }
 
-  addConversation(nick, unread) {
-    const user = this.chat.users.get(nick.toLowerCase()) || new ChatUser(nick);
-    this.usersEl.append(`
-            <li class="conversation unread-${unread}">
-                <a style="flex: 1;" data-username="${user.username}" class="user">${user.displayName}</a>
-                <span class="badge">${unread}</span>
-                <a data-username="${user.username}" title="Hide" class="remove"></a>
-            </li>
-        `);
+  incrementUnread(n = 1) {
+    this.unread = Math.max(0, this.unread + n);
+    this.updateNotification();
+  }
+
+  decrementUnread(n = 1) {
+    this.unread = Math.max(0, this.unread - n);
+    this.updateNotification();
+  }
+
+  // --- fetching / pagination --------------------------------------------
+
+  buildUrl(search, cursor) {
+    const base = `${this.chat.config.api.base}/api/messages/conversations`;
+    const params = new URLSearchParams();
+    if (cursor) {
+      params.set('last-timestamp', cursor.timestamp);
+      params.set('last-id', cursor.id);
+    }
+    if (search) {
+      params.set('search', search);
+    }
+    const qs = params.toString();
+    return qs ? `${base}?${qs}` : base;
+  }
+
+  async fetchPage(search, cursor) {
+    const empty = { results: [], more: false, nextPageOffset: null };
+    this.loading = true;
+    this.updateLoadMore();
+    try {
+      const res = await fetch(this.buildUrl(search, cursor), {
+        credentials: 'include',
+      });
+      const data = await res.json();
+      return data && Array.isArray(data.results) ? data : empty;
+    } catch {
+      return empty;
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  /**
+   * Fold a page of DTOs into the Map and return their keys in order. For a
+   * conversation already known locally, keep the local `unread`/`open` (which
+   * may be ahead of the server) and only refresh the preview fields.
+   */
+  upsertResults(results) {
+    return results.map((dto) => {
+      const key = dto.username.toLowerCase();
+      const existing = this.chat.whispers.get(key);
+      const conv = existing || { open: false, unread: dto.unread };
+      conv.id = dto.userId;
+      conv.nick = dto.username;
+      conv.username = key;
+      conv.lastMessage = dto.lastMessage;
+      conv.timestamp = dto.timestamp;
+      conv.lastMessageFromMe = dto.lastMessageFromMe;
+      this.chat.whispers.set(key, conv);
+      return key;
+    });
+  }
+
+  async loadFirstPage() {
+    const data = await this.fetchPage('', null);
+    this.conversations = this.upsertResults(data.results);
+    this.cursor = data.nextPageOffset;
+    this.more = data.more;
+    this.loaded = true;
+    this.renderList();
+  }
+
+  loadMore() {
+    if (this.loading) {
+      return;
+    }
+    if (this.searchterm) {
+      this.loadNextSearchPage();
+    } else {
+      this.loadNextPage();
+    }
+  }
+
+  async loadNextPage() {
+    if (!this.more || !this.cursor) {
+      return;
+    }
+    const data = await this.fetchPage('', this.cursor);
+    const keys = this.upsertResults(data.results);
+    this.conversations.push(...keys);
+    this.cursor = data.nextPageOffset;
+    this.more = data.more;
+    this.appendRows(keys);
+    this.updateLoadMore();
+  }
+
+  async loadNextSearchPage() {
+    if (!this.searchMore || !this.searchCursor) {
+      return;
+    }
+    const term = this.searchterm;
+    const data = await this.fetchPage(term, this.searchCursor);
+    if (term !== this.searchterm) {
+      return;
+    }
+    const keys = this.upsertResults(data.results);
+    this.searchResults.push(...keys);
+    this.searchCursor = data.nextPageOffset;
+    this.searchMore = data.more;
+    this.appendRows(keys);
+    this.updateLoadMore();
+  }
+
+  // --- search -----------------------------------------------------------
+
+  onSearchChange() {
+    if (this.searchterm === '') {
+      this.searchResults = [];
+      this.searchCursor = null;
+      this.searchMore = false;
+      this.renderList();
+      return;
+    }
+    this.runSearch();
+  }
+
+  async runSearch() {
+    const term = this.searchterm;
+    const seq = (this.searchSeq += 1);
+    const data = await this.fetchPage(term, null);
+    // Ignore a response the user has already typed past.
+    if (seq !== this.searchSeq) {
+      return;
+    }
+    this.searchResults = this.upsertResults(data.results);
+    this.searchCursor = data.nextPageOffset;
+    this.searchMore = data.more;
+    this.renderList();
+  }
+
+  // --- rendering --------------------------------------------------------
+
+  activeKeys() {
+    return this.searchterm ? this.searchResults : this.conversations;
+  }
+
+  activeMore() {
+    return this.searchterm ? this.searchMore : this.more;
+  }
+
+  renderList() {
+    if (!this.visible) {
+      return;
+    }
+    this.listEl.empty();
+    const keys = this.activeKeys();
+    if (keys.length === 0) {
+      this.listEl.append(this.empty);
+    } else {
+      keys.forEach((key) => this.listEl.append(this.buildRow(key)));
+    }
+    this.updateLoadMore();
+  }
+
+  appendRows(keys) {
+    keys.forEach((key) => this.listEl.append(this.buildRow(key)));
+  }
+
+  updateLoadMore() {
+    const button = this.loadMoreEl.find('button');
+    if (this.activeMore()) {
+      this.loadMoreEl.show();
+      button.prop('disabled', this.loading);
+      button.text(this.loading ? 'Loading…' : 'Load more');
+    } else {
+      this.loadMoreEl.hide();
+    }
+  }
+
+  buildRow(key) {
+    const conv = this.chat.whispers.get(key);
+    if (!conv) {
+      return $();
+    }
+    const user = this.chat.users.get(key) || new ChatUser(conv.nick);
+    const unread = conv.unread || 0;
+
+    const row = $(`<li class="conversation unread-${unread}"></li>`).attr(
+      'data-username',
+      user.username,
+    );
+    const header = $('<div class="conversation__header"></div>');
+    // .text() throughout: the preview is arbitrary user-authored message text.
+    $('<span class="conversation__user"></span>')
+      .text(user.displayName)
+      .appendTo(header);
+    if (conv.timestamp != null) {
+      const when = moment(conv.timestamp);
+      $('<time class="conversation__time"></time>')
+        .attr('datetime', when.toISOString())
+        .attr('title', when.format(DATE_FORMATS.FULL))
+        .text(when.fromNow(true))
+        .appendTo(header);
+    }
+    $('<span class="badge"></span>').text(unread).appendTo(header);
+    row.append(header);
+
+    const preview =
+      (conv.lastMessageFromMe ? 'You: ' : '') + (conv.lastMessage || '');
+    $('<div class="conversation__preview"></div>').text(preview).appendTo(row);
+
+    return row;
+  }
+
+  /**
+   * Move a conversation to the top of the normal list (dedupe first). Called
+   * when a whisper is sent or received so recent threads float up.
+   */
+  bumpConversation(key) {
+    const idx = this.conversations.indexOf(key);
+    if (idx !== -1) {
+      this.conversations.splice(idx, 1);
+    }
+    this.conversations.unshift(key);
+    if (this.visible && this.searchterm === '') {
+      this.renderList();
+    }
+  }
+
+  /**
+   * Drop the loaded list so the next open refetches from scratch. Used on
+   * reconnect, where the badge is separately reseeded from the endpoint.
+   */
+  invalidate() {
+    this.loaded = false;
+    this.conversations = [];
+    this.cursor = null;
+    this.more = false;
+    this.searchterm = '';
+    this.searchResults = [];
+    this.searchCursor = null;
+    this.searchMore = false;
+    if (this.searchinput) {
+      this.searchinput.val('');
+    }
+    if (this.visible) {
+      this.loadFirstPage();
+    }
   }
 }

--- a/assets/chat/js/menus/ChatWhisperUsers.test.js
+++ b/assets/chat/js/menus/ChatWhisperUsers.test.js
@@ -24,6 +24,11 @@ const MENU_HTML = `
 
 const EMPTY_PAGE = { results: [], more: false, nextPageOffset: null };
 
+// Wrap a page payload in the JsonResponse envelope the endpoints return.
+function envelope(data) {
+  return JSON.stringify({ success: true, message: null, data, error: null });
+}
+
 function dto(username, overrides = {}) {
   return {
     userId: username.length,
@@ -58,13 +63,13 @@ async function flush() {
 
 beforeEach(() => {
   fetch.resetMocks();
-  fetch.mockResponse(JSON.stringify(EMPTY_PAGE));
+  fetch.mockResponse(envelope(EMPTY_PAGE));
 });
 
 describe('ChatWhisperUsers list', () => {
   it('loads the first page on show and renders rows newest-first', async () => {
     fetch.mockResponseOnce(
-      JSON.stringify({
+      envelope({
         results: [
           dto('Alice', { unread: 2 }),
           dto('Bob', { lastMessage: 'yo', lastMessageFromMe: true }),
@@ -95,7 +100,7 @@ describe('ChatWhisperUsers list', () => {
 
   it('appends the next page and passes the cursor, hiding the button when done', async () => {
     fetch.mockResponseOnce(
-      JSON.stringify({
+      envelope({
         results: [dto('Alice')],
         more: true,
         nextPageOffset: { timestamp: '2026-01-01 09:00:00.000', id: 42 },
@@ -107,7 +112,7 @@ describe('ChatWhisperUsers list', () => {
     expect(menu.loadMoreEl.get(0).style.display).not.toBe('none');
 
     fetch.mockResponseOnce(
-      JSON.stringify({
+      envelope({
         results: [dto('Bob')],
         more: false,
         nextPageOffset: null,
@@ -127,7 +132,7 @@ describe('ChatWhisperUsers list', () => {
 
   it('searches server-side and restores the normal list on clear without refetching', async () => {
     fetch.mockResponseOnce(
-      JSON.stringify({
+      envelope({
         results: [dto('Alice'), dto('Bob')],
         more: false,
         nextPageOffset: null,
@@ -139,7 +144,7 @@ describe('ChatWhisperUsers list', () => {
     expect(ui.find('.conversation').length).toBe(2);
 
     fetch.mockResponseOnce(
-      JSON.stringify({
+      envelope({
         results: [dto('Alice')],
         more: false,
         nextPageOffset: null,

--- a/assets/chat/js/menus/ChatWhisperUsers.test.js
+++ b/assets/chat/js/menus/ChatWhisperUsers.test.js
@@ -1,0 +1,220 @@
+// @ts-nocheck
+
+// The scroll plugin pulls in a CSS import jest can't parse; the fixture omits
+// `.scrollable` so the base menu never builds one, and this stub keeps the
+// import chain JS-only.
+jest.mock('../scroll', () => ({ __esModule: true, default: class {} }));
+
+import $ from 'jquery';
+import ChatWhisperUsers from './ChatWhisperUsers';
+
+const MENU_HTML = `
+  <div id="chat-whisper-users">
+    <div class="toolbar"><h5><span>Whispers</span></h5></div>
+    <div class="content">
+      <ul></ul>
+      <div class="whisper-load-more" style="display: none">
+        <button type="button">Load more</button>
+      </div>
+    </div>
+    <div id="chat-whisper-search">
+      <input type="text" class="form-control" value="" />
+    </div>
+  </div>`;
+
+const EMPTY_PAGE = { results: [], more: false, nextPageOffset: null };
+
+function dto(username, overrides = {}) {
+  return {
+    userId: username.length,
+    username,
+    lastMessage: `msg from ${username}`,
+    timestamp: '2026-01-01T10:00:00+0000',
+    unread: 0,
+    lastMessageFromMe: false,
+    ...overrides,
+  };
+}
+
+function makeMenu() {
+  const ui = $(MENU_HTML);
+  const chat = {
+    whispers: new Map(),
+    users: new Map(),
+    config: { api: { base: '' } },
+    isDesktop: false,
+    openConversation: jest.fn(),
+  };
+  const menu = new ChatWhisperUsers(ui, $('<div></div>'), chat);
+  return { menu, ui, chat };
+}
+
+// Flush the fetch → json → render promise chain.
+async function flush() {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  fetch.resetMocks();
+  fetch.mockResponse(JSON.stringify(EMPTY_PAGE));
+});
+
+describe('ChatWhisperUsers list', () => {
+  it('loads the first page on show and renders rows newest-first', async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        results: [
+          dto('Alice', { unread: 2 }),
+          dto('Bob', { lastMessage: 'yo', lastMessageFromMe: true }),
+        ],
+        more: false,
+        nextPageOffset: null,
+      }),
+    );
+    const { menu, ui } = makeMenu();
+
+    menu.show();
+    await flush();
+
+    const rows = ui.find('.conversation');
+    expect(rows.length).toBe(2);
+    expect(rows.eq(0).find('.conversation__user').text()).toBe('Alice');
+    expect(rows.eq(0).find('.badge').text()).toBe('2');
+    // "You:" prefix when the last message was sent by the viewer.
+    expect(rows.eq(1).find('.conversation__preview').text()).toBe('You: yo');
+    // Read row is marked so CSS can dim it.
+    expect(rows.eq(1).hasClass('unread-0')).toBe(true);
+  });
+
+  it('appends the next page and passes the cursor, hiding the button when done', async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        results: [dto('Alice')],
+        more: true,
+        nextPageOffset: { timestamp: '2026-01-01 09:00:00.000', id: 42 },
+      }),
+    );
+    const { menu, ui } = makeMenu();
+    menu.show();
+    await flush();
+    expect(menu.loadMoreEl.get(0).style.display).not.toBe('none');
+
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        results: [dto('Bob')],
+        more: false,
+        nextPageOffset: null,
+      }),
+    );
+    menu.loadMore();
+    await flush();
+
+    // Page 1 row is kept, page 2 appended (not a rebuild).
+    expect(ui.find('.conversation').length).toBe(2);
+    const lastUrl = fetch.mock.calls[fetch.mock.calls.length - 1][0];
+    expect(lastUrl).toContain('last-timestamp=');
+    expect(lastUrl).toContain('last-id=42');
+    // No more pages → button hidden.
+    expect(menu.loadMoreEl.get(0).style.display).toBe('none');
+  });
+
+  it('searches server-side and restores the normal list on clear without refetching', async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        results: [dto('Alice'), dto('Bob')],
+        more: false,
+        nextPageOffset: null,
+      }),
+    );
+    const { menu, ui } = makeMenu();
+    menu.show();
+    await flush();
+    expect(ui.find('.conversation').length).toBe(2);
+
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        results: [dto('Alice')],
+        more: false,
+        nextPageOffset: null,
+      }),
+    );
+    menu.searchterm = 'ali';
+    menu.onSearchChange();
+    await flush();
+
+    expect(ui.find('.conversation').length).toBe(1);
+    const searchUrl = fetch.mock.calls[fetch.mock.calls.length - 1][0];
+    expect(searchUrl).toContain('search=ali');
+
+    const callsBeforeClear = fetch.mock.calls.length;
+    menu.searchterm = '';
+    menu.onSearchChange();
+    await flush();
+
+    // Clearing search re-renders the retained normal list — no new request.
+    expect(ui.find('.conversation').length).toBe(2);
+    expect(fetch.mock.calls.length).toBe(callsBeforeClear);
+  });
+});
+
+describe('ChatWhisperUsers badge', () => {
+  it('renders the scalar count and never sums the whispers Map', () => {
+    const { menu, chat } = makeMenu();
+    // Stale per-conversation counts that must NOT influence the badge.
+    chat.whispers.set('alice', { unread: 99 });
+    const indicator = menu.notif;
+
+    menu.seedUnread(5);
+    expect(indicator.text()).toBe('5');
+    expect(indicator.get(0).style.display).not.toBe('none');
+
+    menu.decrementUnread(2);
+    expect(indicator.text()).toBe('3');
+
+    menu.incrementUnread(1);
+    expect(indicator.text()).toBe('4');
+
+    menu.seedUnread(0);
+    expect(indicator.text()).toBe('0');
+    expect(indicator.get(0).style.display).toBe('none');
+  });
+
+  it('never goes negative', () => {
+    const { menu } = makeMenu();
+    menu.seedUnread(1);
+    menu.decrementUnread(5);
+    expect(menu.notif.text()).toBe('0');
+  });
+});
+
+describe('ChatWhisperUsers rows', () => {
+  it('renders the message preview as text so markup cannot inject', () => {
+    const { menu, chat } = makeMenu();
+    chat.whispers.set('alice', {
+      nick: 'Alice',
+      username: 'alice',
+      unread: 0,
+      lastMessage: '<b>pwned</b>',
+      timestamp: null,
+      lastMessageFromMe: false,
+    });
+
+    const row = menu.buildRow('alice');
+    const preview = row.find('.conversation__preview');
+    expect(preview.text()).toBe('<b>pwned</b>');
+    expect(preview.find('b').length).toBe(0);
+  });
+
+  it('moves a conversation to the top and dedupes', () => {
+    const { menu } = makeMenu();
+    menu.conversations = ['a', 'b', 'c'];
+
+    menu.bumpConversation('c');
+    expect(menu.conversations).toEqual(['c', 'a', 'b']);
+
+    menu.bumpConversation('d');
+    expect(menu.conversations).toEqual(['d', 'c', 'a', 'b']);
+  });
+});

--- a/assets/chat/js/menus/ChatWhisperUsers.test.js
+++ b/assets/chat/js/menus/ChatWhisperUsers.test.js
@@ -192,6 +192,22 @@ describe('ChatWhisperUsers badge', () => {
     menu.decrementUnread(5);
     expect(menu.notif.text()).toBe('0');
   });
+
+  it('caps the total and title at 99+ and does not stack the prefix', () => {
+    const { menu } = makeMenu();
+    window.parent.document.title = 'Destiny';
+
+    menu.seedUnread(150);
+    expect(menu.notif.text()).toBe('99+');
+    expect(window.parent.document.title).toBe('(99+) Destiny');
+
+    // Re-seeding replaces the capped prefix rather than stacking it.
+    menu.seedUnread(120);
+    expect(window.parent.document.title).toBe('(99+) Destiny');
+
+    menu.seedUnread(0);
+    expect(window.parent.document.title).toBe('Destiny');
+  });
 });
 
 describe('ChatWhisperUsers rows', () => {
@@ -210,6 +226,21 @@ describe('ChatWhisperUsers rows', () => {
     const preview = row.find('.conversation__preview');
     expect(preview.text()).toBe('<b>pwned</b>');
     expect(preview.find('b').length).toBe(0);
+  });
+
+  it('caps the count badge at 99+', () => {
+    const { menu, chat } = makeMenu();
+    chat.whispers.set('alice', {
+      nick: 'Alice',
+      username: 'alice',
+      unread: 150,
+      lastMessage: 'hi',
+      timestamp: null,
+      lastMessageFromMe: false,
+    });
+
+    const row = menu.buildRow('alice');
+    expect(row.find('.conversation__count').text()).toBe('99+ new');
   });
 
   it('moves a conversation to the top and dedupes', () => {

--- a/assets/chat/js/menus/ChatWhisperUsers.test.js
+++ b/assets/chat/js/menus/ChatWhisperUsers.test.js
@@ -81,11 +81,16 @@ describe('ChatWhisperUsers list', () => {
     const rows = ui.find('.conversation');
     expect(rows.length).toBe(2);
     expect(rows.eq(0).find('.conversation__user').text()).toBe('Alice');
-    expect(rows.eq(0).find('.badge').text()).toBe('2');
+    // Unread row: a "N new" count badge left of the time, flagged for the dot.
+    expect(rows.eq(0).find('.conversation__count').text()).toBe('2 new');
+    expect(rows.eq(0).hasClass('conversation--unread')).toBe(true);
+    // Relative time carries the "ago" suffix.
+    expect(rows.eq(0).find('.conversation__time').text()).toContain('ago');
     // "You:" prefix when the last message was sent by the viewer.
     expect(rows.eq(1).find('.conversation__preview').text()).toBe('You: yo');
-    // Read row is marked so CSS can dim it.
-    expect(rows.eq(1).hasClass('unread-0')).toBe(true);
+    // Read row: no count, not flagged.
+    expect(rows.eq(1).find('.conversation__count').length).toBe(0);
+    expect(rows.eq(1).hasClass('conversation--unread')).toBe(false);
   });
 
   it('appends the next page and passes the cursor, hiding the button when done', async () => {

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -425,7 +425,18 @@
       <div class="scrollable">
         <div class="content">
           <ul></ul>
+          <div class="whisper-load-more" style="display: none">
+            <button type="button" class="chat-load-more-btn">Load more</button>
+          </div>
         </div>
+      </div>
+      <div id="chat-whisper-search">
+        <input
+          type="text"
+          class="form-control"
+          value=""
+          placeholder="Username search ..."
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
The whisper panel showed only unread whispers and derived the toolbar badge by summing that list. This splits the unread count from the conversation list and makes the panel a real DM list.

## What changes
- **Badge** seeded from the new scalar `GET /api/messages/unread-count` on connect and kept live locally — incremented on a whisper to a non-active window, decremented by a thread's unread when it's opened. No longer summed from the (now partial) list. Capped at "99+" (both the per-conversation badge and the toolbar total/title).
- **List** shows all conversations newest-first from `GET /api/messages/conversations`, loaded lazily on first open, one page at a time behind a "Load more" button. A new DM floats its thread to the top live.
- **Search** — a bottom field like the user list, but server-side (the list is partial), debounced, with a sequence token dropping out-of-order responses; clearing restores the normal list without a refetch.
- **Rows** show a leading unread dot (blue unread / dim grey read — the username colour no longer encodes unread), an "N new" count chip, a relative "… ago" time, and a message preview ("You:" when you sent it). Rendered with `.text()`, never string interpolation, since the preview is arbitrary user text.

`chat.whispers` stays the single keyed store the window code relies on; the panel only owns display order (separate key arrays for normal vs search), and every render reads live fields back out of the Map. Entries are never deleted now (the per-row hide was removed), which strengthens the invariant that every open whisper window has a Map entry.

## Verification
`ChatWhisperUsers.test.js` covers lazy first load + ordering, Load-more cursor append, server-side search + restore, the scalar badge (never summed, no-negative, "99+" cap + no title-prefix stacking), XSS-safe preview, and move-to-top dedupe. Full jest suite (13 suites) + eslint + production build all green. The row design was iterated from static-preview screenshots.

## Dependencies & caveats
> ⚠️ Requires the new website endpoints (destinygg/website-private #1342, itself stacked on #1341) **live in production** before this ships — it calls `/api/messages/unread-count` and `/api/messages/conversations`.

**Not yet verified in a live browser.** Unit tests cover the seams, but the full `onPRIVMSG → panel render` path and the visual result haven't been exercised in a running chat embed. Recommend a manual pass (receive a whisper with the panel open, Load more, search, open a thread, reconnect) before merge.

Known follow-up: relative times on already-rendered rows don't auto-tick — a row's time refreshes only when it re-renders.