### PR TITLE
Back off properly when a connection is rejected on open

### DIFF
--- a/assets/chat/js/source.js
+++ b/assets/chat/js/source.js
@@ -3,6 +3,31 @@ import EventEmitter from './emitter';
 const WebSocket = window.WebSocket || window.MozWebSocket;
 
 /**
+ * How long a socket must stay open before we treat the connection as healthy.
+ * The backend completes the WebSocket handshake *before* it authenticates, so a
+ * connection it then rejects still fires `onopen` first. Without this threshold
+ * such a connection would count as a success and pin us to the shortest retry
+ * window forever.
+ */
+const STABLE_CONNECTION_MS = 5000;
+
+/** Retry window for the first attempt after a healthy connection dropped. */
+const RETRY_WINDOW_MS = 3000;
+
+/** Ceiling for the retry window, however many attempts have failed. */
+const RETRY_WINDOW_CAP_MS = 60000;
+
+/** Floor for any retry, so we never hammer the backend back-to-back. */
+const RETRY_MIN_MS = 500;
+
+/**
+ * Spread for a Going Away reconnect. Cloudflare cycling a server closes every
+ * client on it at the same instant, so even a deliberately fast retry needs
+ * jitter or the whole fleet lands on the backend together.
+ */
+const GOING_AWAY_SPREAD_MS = 1000;
+
+/**
  * Handles the websocket connection, opening, closing, retrying
  * and parsing the standard format from the golang dgg service `$EVENT ${DATA}`
  * extends the EventEmitter so you can bind to the events using source.on(name, fn)
@@ -28,6 +53,7 @@ class ChatSource extends EventEmitter {
     this.retryOnDisconnect = true;
     this.retryAttempts = 0;
     this.retryTimer = null;
+    this.connectedAt = null;
   }
 
   isConnected() {
@@ -37,6 +63,7 @@ class ChatSource extends EventEmitter {
   connect(url) {
     this.url = url;
     this.retryAttempts += 1;
+    this.connectedAt = null;
     try {
       if (this.retryTimer !== null) {
         clearTimeout(this.retryTimer);
@@ -70,27 +97,61 @@ class ChatSource extends EventEmitter {
   }
 
   onOpen(e) {
+    this.connectedAt = Date.now();
     this.emit('OPEN', e);
-    this.retryAttempts = 0;
     this.retryOnDisconnect = true;
   }
 
   onClose(e) {
-    // 1001 is the Going Away code, since it happens frequently when CloudFlare servers update, we just instantly reconnect silently
-    if (e.code === 1001) {
-      this.connect(this.url);
+    // Opening the socket is not success on its own — only a connection that
+    // held up counts, otherwise a backend that accepts and immediately closes
+    // (auth unavailable, mid-deploy) never escalates and gets retried forever
+    // at the shortest interval.
+    const stable =
+      this.connectedAt !== null &&
+      Date.now() - this.connectedAt >= STABLE_CONNECTION_MS;
+    this.connectedAt = null;
+
+    if (stable) {
+      this.retryAttempts = 0;
+    }
+
+    if (!this.retryOnDisconnect) {
+      this.emit('CLOSE', 0);
       return;
     }
-    let retryMilli = 0;
-    if (this.retryOnDisconnect) {
-      // If a disconnect is experienced after the last attempt was successful, the retry timeout is very short, else its longer
-      retryMilli =
-        this.retryAttempts === 0
-          ? Math.floor(Math.random() * (3000 - 501 + 1)) + 501
-          : Math.floor(Math.random() * (30000 - 5000 + 1)) + 5000;
-      this.retryTimer = setTimeout(() => this.connect(this.url), retryMilli);
+
+    // 1001 is the Going Away code, it happens routinely when CloudFlare servers
+    // update, so reconnect quickly and without the user-facing countdown. Only
+    // from a healthy connection though — a backend stuck sending 1001 would
+    // otherwise spin here instead of backing off.
+    if (e.code === 1001 && stable) {
+      this.retryTimer = setTimeout(
+        () => this.connect(this.url),
+        Math.floor(Math.random() * GOING_AWAY_SPREAD_MS),
+      );
+      this.emit('CLOSE', 0);
+      return;
     }
+
+    const retryMilli = this.retryDelay();
+    this.retryTimer = setTimeout(() => this.connect(this.url), retryMilli);
     this.emit('CLOSE', retryMilli);
+  }
+
+  /**
+   * Full jitter over a window that doubles with each consecutive failed
+   * attempt. The jitter matters as much as the backoff: a mass disconnect
+   * releases every client at once, and a fixed retry band just reschedules the
+   * stampede instead of spreading it.
+   * @return {number} milliseconds to wait before the next attempt
+   */
+  retryDelay() {
+    const windowMs = Math.min(
+      RETRY_WINDOW_CAP_MS,
+      RETRY_WINDOW_MS * 2 ** this.retryAttempts,
+    );
+    return RETRY_MIN_MS + Math.floor(Math.random() * (windowMs - RETRY_MIN_MS));
   }
 
   onMsg(e) {

--- a/assets/chat/js/source.test.js
+++ b/assets/chat/js/source.test.js
@@ -1,0 +1,165 @@
+/**
+ * `source.js` captures `window.WebSocket` at module load time, so the stub has
+ * to be installed before the module is imported.
+ */
+class FakeWebSocket {
+  constructor(url) {
+    this.url = url;
+    this.readyState = FakeWebSocket.CONNECTING;
+    FakeWebSocket.instances.push(this);
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+}
+FakeWebSocket.instances = [];
+FakeWebSocket.CONNECTING = 0;
+FakeWebSocket.OPEN = 1;
+FakeWebSocket.CLOSED = 3;
+// `source.js` reads these off the instance (`this.socket.OPEN`).
+FakeWebSocket.prototype.CONNECTING = 0;
+FakeWebSocket.prototype.OPEN = 1;
+FakeWebSocket.prototype.CLOSED = 3;
+
+window.WebSocket = FakeWebSocket;
+
+const ChatSource = require('./source').default;
+
+const URL = 'wss://chat.destiny.gg/ws';
+
+/**
+ * Build a source that records every retry delay it schedules.
+ * @return {{source: object, delays: number[]}}
+ */
+function buildSource() {
+  const source = new ChatSource();
+  const delays = [];
+  source.on('CLOSE', (retryMilli) => delays.push(retryMilli));
+  return { source, delays };
+}
+
+/**
+ * Drive one connection attempt that opens, survives `aliveMs`, then closes.
+ * @param {object} source
+ * @param {number} aliveMs how long the socket stays open
+ * @param {number} code the close code
+ */
+function connectThenClose(source, aliveMs, code = 1006) {
+  source.connect(URL);
+  source.onOpen({});
+  jest.advanceTimersByTime(aliveMs);
+  source.onClose({ code });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  FakeWebSocket.instances = [];
+  // Midpoint of the jitter range, so each delay is a deterministic function of
+  // the current retry window.
+  jest.spyOn(Math, 'random').mockReturnValue(0.5);
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe('Reconnect backoff', () => {
+  test('escalates when the socket opens but is closed straight away', () => {
+    const { source, delays } = buildSource();
+
+    // The backend completes the handshake, then rejects: `onopen` fires and is
+    // followed almost immediately by `onclose`. This must not read as success.
+    for (let i = 0; i < 3; i += 1) {
+      connectThenClose(source, 20, 1013);
+    }
+
+    expect(delays).toHaveLength(3);
+    expect(delays[1]).toBeGreaterThan(delays[0]);
+    expect(delays[2]).toBeGreaterThan(delays[1]);
+  });
+
+  test('resets the escalation once a connection has held up', () => {
+    const { source, delays } = buildSource();
+
+    connectThenClose(source, 20, 1013);
+    connectThenClose(source, 20, 1013);
+    const escalated = delays[delays.length - 1];
+
+    // A connection that stays open past the threshold is a real success.
+    connectThenClose(source, 60000, 1006);
+
+    const afterStable = delays[delays.length - 1];
+    expect(afterStable).toBeLessThan(escalated);
+
+    // ...and it is back to the first window, matching a plain healthy drop.
+    const { source: fresh, delays: freshDelays } = buildSource();
+    connectThenClose(fresh, 60000, 1006);
+    expect(afterStable).toBe(freshDelays[0]);
+  });
+
+  test('caps the retry window however many attempts have failed', () => {
+    const { source, delays } = buildSource();
+
+    for (let i = 0; i < 12; i += 1) {
+      connectThenClose(source, 20, 1013);
+    }
+
+    expect(delays[delays.length - 1]).toBeLessThanOrEqual(60000);
+    expect(delays[delays.length - 1]).toBe(delays[delays.length - 2]);
+  });
+
+  test('never schedules a retry back-to-back', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const { source, delays } = buildSource();
+
+    connectThenClose(source, 60000, 1006);
+
+    expect(delays[0]).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe('Going Away (1001)', () => {
+  test('reconnects quickly and silently, but not instantly', () => {
+    const { source, delays } = buildSource();
+
+    connectThenClose(source, 60000, 1001);
+
+    // Silent: no countdown is reported to the user.
+    expect(delays).toEqual([0]);
+    // Deferred rather than reconnected inline, so the retry can be jittered.
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    jest.advanceTimersByTime(1000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  test('falls back to normal backoff when the connection was not healthy', () => {
+    const { source, delays } = buildSource();
+
+    // A backend stuck sending 1001 must not pin us to the fast path.
+    connectThenClose(source, 20, 1001);
+
+    expect(delays[0]).toBeGreaterThan(0);
+  });
+});
+
+describe('Permanent disconnects', () => {
+  test('schedules nothing once retrying is disabled', () => {
+    const { source, delays } = buildSource();
+
+    source.connect(URL);
+    source.onOpen({});
+    // The client sets this from `onERR` on a `banned` / `toomanyconnections`
+    // error, which arrives over the already-open socket.
+    source.retryOnDisconnect = false;
+    jest.advanceTimersByTime(60000);
+    source.onClose({ code: 1006 });
+
+    expect(delays).toEqual([0]);
+    jest.advanceTimersByTime(120000);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Problem

The chat backend completes the WebSocket handshake *before* it authenticates, so a connection it then rejects still fires `onopen` in the browser.

`onOpen` reset `retryAttempts = 0`, which scored every such rejection as a success and pinned the client to the shortest retry band — a 501–3000ms reconnect, forever. The long 5–30s band only applied when the socket never opened, which this path never hits.

The practical effect: a website too slow to answer `/api/chat/sessionauth` had every logged-in client re-hammering it roughly every 1.75s, indefinitely. Because each of those handshakes costs a PHP request against a pool of 100 FPM workers, the load sustained itself well past whatever caused the original slowdown. This showed up as the site grinding to a halt after a chat backend restart.

## Changes

**Judge success by whether the connection held up.** `connectedAt` is stamped in `onOpen` and checked in `onClose` against a 5s stability threshold; only a connection that survives it resets the attempt counter.

**Real backoff with full jitter.** The two fixed bands are replaced by a window that doubles per consecutive failure — 3s → 6s → 12s → 24s → 48s, capped at 60s, floored at 500ms. The first window deliberately matches the old healthy-drop behaviour (~500–3000ms), so a brief blip still reconnects just as fast as before; only repeated failure escalates.

Full jitter rather than a fixed band is the point: a mass disconnect releases every client simultaneously, and a band just reschedules the stampede instead of spreading it.

**1001 Going Away no longer reconnects inline.** It keeps the fast, silent path (no user-facing countdown) but spreads over 0–1000ms, since Cloudflare cycling a server closes every client on it at the same instant. Two related fixes: it now requires a healthy prior connection, so a backend stuck emitting 1001 backs off instead of spinning; and it no longer bypasses `retryOnDisconnect`, which previously let a banned user reconnect.

## Tests

New `source.test.js`, 7 cases: the regression itself (open-then-immediately-closed must escalate), the stability reset, the window cap, the minimum delay, both 1001 paths, and the disabled-retry path.

Full suite passes (276 tests), lint and Prettier clean.

## Notes for review

- The 5s stability threshold is a judgement call. Long enough that a rejected handshake never qualifies, short enough that a genuinely healthy connection always does.
- This is a client-side mitigation for one part of a larger reconnect-storm problem. The server-side work — batching the NAMES rebuild and the JOIN/QUIT fanout, which are quadratic in connected users — is separate and still to come.