### PR TITLE
Handle batched presence changes from the chat server

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -140,6 +140,7 @@ class Chat {
     this.source.on('HISTORY', (data) => this.onHISTORY(data));
     this.source.on('PIN', (data) => this.onPIN(data));
     this.source.on('QUIT', (data) => this.onQUIT(data));
+    this.source.on('USERSDELTA', (data) => this.onUSERSDELTA(data));
     this.source.on('MSG', (data) => this.onMSG(data));
     this.source.on('MUTE', (data) => this.onMUTE(data));
     this.source.on('UNMUTE', (data) => this.onUNMUTE(data));
@@ -1307,6 +1308,17 @@ class Chat {
       this.users.delete(normalized);
       this.autocomplete.remove(data.nick, true);
     }
+  }
+
+  /**
+   * A batch of presence changes, sent in place of individual JOIN/QUIT events
+   * when a lot of them land at once (a chat restart, say). Joiners arrive under
+   * `users` and are already picked up by `onDISPATCH`, which harvests that key
+   * from any event — only the departures need handling here.
+   * @param {{users?: object[], removed?: object[]}} data
+   */
+  onUSERSDELTA(data) {
+    (data.removed ?? []).forEach((user) => this.onQUIT(user));
   }
 
   onMSG(data) {

--- a/assets/chat/js/menus/ChatUserMenu.js
+++ b/assets/chat/js/menus/ChatUserMenu.js
@@ -43,6 +43,7 @@ export default class ChatUserMenu extends ChatMenu {
     this.sections = new Map();
     this.header = this.ui.find('h5 span');
     this.container = this.ui.find('.content:first');
+    this.buildSections();
     this.searchinput = this.ui.find(
       '#chat-user-list-search .form-control:first',
     );
@@ -75,6 +76,7 @@ export default class ChatUserMenu extends ChatMenu {
     this.chat.source.on('JOIN', (data) => this.addAndRedraw(data));
     this.chat.source.on('QUIT', (data) => this.removeAndRedraw(data));
     this.chat.source.on('NAMES', (data) => this.addAll(data.users));
+    this.chat.source.on('USERSDELTA', (data) => this.applyDelta(data));
     this.chat.source.on('UPDATEUSER', (data) => this.replaceAndRedraw(data));
     this.searchinput.on(
       'keyup',
@@ -151,7 +153,12 @@ export default class ChatUserMenu extends ChatMenu {
     return features !== '' ? `<span class="features">${features}</span>` : '';
   }
 
-  addAll(users) {
+  /**
+   * Lay out the fixed set of sections users get bucketed into. Called up front
+   * as well as on NAMES: presence events can arrive before the first snapshot
+   * does, and every user lookup needs the sections to already exist.
+   */
+  buildSections() {
     this.totalcount = 0;
     this.container.empty();
     this.sections = new Map();
@@ -162,6 +169,10 @@ export default class ChatUserMenu extends ChatMenu {
         this.flairSection.set(flair, data.name),
       );
     });
+  }
+
+  addAll(users) {
+    this.buildSections();
     users.forEach((u) => this.addElement(u));
     this.sort();
     this.filter();
@@ -180,6 +191,38 @@ export default class ChatUserMenu extends ChatMenu {
     const el = this.getElement(user);
     if (el) {
       this.removeElement(el);
+      this.redraw();
+    }
+  }
+
+  /**
+   * Apply a batch of presence changes. The server sends these instead of
+   * individual JOIN/QUIT events once enough of them land in one tick, so this
+   * favours one bulk sort and a single redraw over per-user insertion and a
+   * redraw each.
+   * @param {{users?: object[], removed?: object[]}} data
+   */
+  applyDelta(data) {
+    let changed = false;
+
+    (data.removed ?? []).forEach((user) => {
+      const el = this.getElement(user);
+      if (el) {
+        this.removeElement(el);
+        changed = true;
+      }
+    });
+
+    (data.users ?? []).forEach((user) => {
+      if (!this.getElement(user)) {
+        this.addElement(user);
+        changed = true;
+      }
+    });
+
+    if (changed) {
+      this.sort();
+      this.filter();
       this.redraw();
     }
   }


### PR DESCRIPTION
## Context

Server-side counterpart: destinygg/chat-private#86.

The chat backend rebuilt the entire names snapshot on every connect and broadcast a JOIN per arriving user — both O(connected users), so a mass reconnect was quadratic and could stall the server for tens of seconds. It now rebuilds on a ticker and collapses presence changes into a single `USERSDELTA` once more than 32 land in one tick.

**This PR is not required for that change to ship.** `USERSDELTA` keys its joiners under `users`, which `onDISPATCH` already harvests from any event, so current clients pick up arrivals with no change at all — they just miss removals until their next reconnect. This closes that gap and handles the batch efficiently.

Independent of #872; both fork from `master` and touch different files.

## Changes

**`onUSERSDELTA`** handles departures only, forwarding each to the existing `onQUIT`. Joiners need no new code for the reasons above.

**`ChatUserMenu.applyDelta`** applies the whole batch, then sorts and redraws **once**. The individual JOIN/QUIT handlers do a binary-search insert plus a `filter()` and `redraw()` per user, which is right for one or two users and badly wrong for a batch that can hold thousands. This is the same bulk strategy `addAll` already uses for NAMES.

**Sections are now built in the constructor**, not only in `addAll`. Every user lookup resolves a section first (`getElement` → `highestSection` → `sections.get`), and `sections` started as an empty `Map`, so a presence event arriving before the first NAMES threw a `TypeError` on `section.users`.

That was already reachable on `master` — a JOIN can land between a connection registering with the hub and its NAMES being sent, a window that includes a redis `LRANGE` for history. The server now serves NAMES from the next tick, which widens it enough that I did not want to leave it.

## Testing gap — please read

**These changes have no unit tests, and that is a tooling limitation rather than a choice.**

`chat.js` cannot be imported under jest: `yargs-parser/browser` ships untransformed ESM, and because the repo uses `.babelrc` rather than a root `babel.config.js`, Babel will not transform anything under `node_modules`. Adding `transformIgnorePatterns` alone does not fix it — the Babel config has to move to root mode, which also feeds the webpack build. I reverted that attempt rather than risk the bundle in this PR.

The existing suite (269 tests) passes, and lint and Prettier are clean, but the new code paths here are verified by reading only. Making `chat.js` testable is worth its own PR.

## Manual verification checklist for reviewers

- User list and autocomplete stay correct across a chat server restart
- A batch arriving before the first NAMES does not throw
- Individual JOIN/QUIT still behave as before under normal traffic (below the server's threshold, they are still what gets sent)