### PR TITLE
Fix babel-loader exclude regex so transpilation actually runs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,7 +87,7 @@ module.exports = {
     rules: [
       {
         test: /\.m?js$/,
-        exclude: /(node_modules|)/,
+        exclude: /node_modules/,
         loader: 'babel-loader',
         options: { presets: ['@babel/preset-env'] },
       },


### PR DESCRIPTION
`exclude: /(node_modules|)/` in `webpack.config.js` has an empty right-hand alternative, so the pattern matches at offset 0 of any string. The exclude therefore applies to **every** file, and `@babel/preset-env` never runs on anything.

### Evidence

Built the production bundle both ways on `bea7d14`:

| | bundle size | `tiers=new Set` — the ES2022 class field from `assets/chat/js/emotes.js:2` |
|---|---|---|
| before | 756,982 bytes | present verbatim |
| after | 772,695 bytes | lowered into the constructor |

So the shipped bundle carries whatever syntax the source happens to be written in, and the `browserslist` field is inert. `npx browserslist` on the configured query still resolves to targets including `ios_saf 11.0-11.2` and `and_uc 15.5`, neither of which supports class fields or optional chaining; both used throughout `assets/chat/js`. Those browsers get a parse-time `SyntaxError` and no chat at all.

### Scope

The affected browser share is small in 2026 and there's no security impact, so this isn't urgent. The reason to fix it is forward-looking: every future syntax feature the project adopts currently ships unguarded, and the `browserslist` config silently does nothing.

If excluding nothing was actually the intent, dropping the key entirely would express that more clearly than a regex that matches everything — happy to switch this PR to that instead.

### Checks

`npx jest` — 269 passed, 13 suites. `eslint` and `prettier` clean. Production build succeeds with only the pre-existing entrypoint-size warnings.
