### PR TITLE
Guard the features span lookup when pinning a message

### DIFF
--- a/assets/chat/js/messages/PinnedMessage.js
+++ b/assets/chat/js/messages/PinnedMessage.js
@@ -86,7 +86,7 @@ export default class PinnedMessage extends ChatUserMessage {
     this.ui.id = 'msg-pinned';
     this.ui.classList.toggle('msg-pinned', true);
     this.displayed = visibility;
-    this.ui.querySelector('span.features').classList.toggle('hidden', true);
+    this.ui.querySelector('span.features')?.classList.toggle('hidden', true);
     chat.mainwindow.update();
 
     if (chat.user.hasModPowers()) {


### PR DESCRIPTION
`PinnedMessage.pin()` calls `.classList` on the result of `querySelector('span.features')` without a guard. That element might not always exist.

`PinnedMessage` extends `ChatUserMessage` and doesn't override `html()`, so its DOM comes from `buildFeatures()` which returns `''`, emitting no `span.features` element at all, whenever no feature survives the `flairsMap` filter:

```js
return features !== '' ? `<span class="features">${features}</span>` : '';
```

## fix

added guard

