### PR TITLE
Open a menu when a username is left-clicked

### DIFF
--- a/assets/chat/css/menus/_index.scss
+++ b/assets/chat/css/menus/_index.scss
@@ -8,6 +8,7 @@
 @use 'user-list';
 @use 'whispers-list';
 @use 'event-action-menu';
+@use 'user-action-menu';
 
 .chat-menu {
   display: none;

--- a/assets/chat/css/menus/_user-action-menu.scss
+++ b/assets/chat/css/menus/_user-action-menu.scss
@@ -1,0 +1,25 @@
+@use '../abstracts/' as a;
+
+#user-action-menu {
+  height: fit-content;
+  width: fit-content;
+  min-width: 75px;
+  max-width: 250px;
+  z-index: 221;
+
+  .chat-menu-inner {
+    background-color: a.$color-surface-dark3;
+  }
+
+  .user-action {
+    transition: background-color 150ms ease;
+    color: a.$color-light;
+    padding: 0.5rem 1rem;
+    text-align: left;
+    white-space: nowrap;
+
+    &:hover {
+      background-color: a.$color-surface-dark4;
+    }
+  }
+}

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -32,6 +32,7 @@ import {
   ChatEmoteTooltip,
   ChatSettingsMenu,
   ChatUserInfoMenu,
+  ChatUserActionMenu,
   ChatEventActionMenu,
 } from './menus';
 import ChatEventBar from './event-bar/EventBar';
@@ -398,6 +399,14 @@ class Chat {
       'user-info',
       new ChatUserInfoMenu(
         this.ui.find('#chat-user-info'),
+        this.output.find('.msg-user .user'),
+        this,
+      ),
+    );
+    this.menus.set(
+      'user-action',
+      new ChatUserActionMenu(
+        this.ui.find('#user-action-menu'),
         this.output.find('.msg-user .user'),
         this,
       ),

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -535,7 +535,9 @@ class Chat {
       if (isKeyCode(e, KEYCODES.ESC)) {
         const activeWindow = this.getActiveWindow();
         if (this.getActiveMenu()) {
-          ChatMenu.closeMenus(this);
+          // ESC is a deliberate dismissal, so it closes the menus that a click
+          // elsewhere leaves alone as well.
+          ChatMenu.closeMenus(this, { all: true });
         } else if (this.eventBar.isEventSelected()) {
           this.eventBar.unselect();
         } else if (!activeWindow.isScrollPinned()) {

--- a/assets/chat/js/focus.js
+++ b/assets/chat/js/focus.js
@@ -52,6 +52,11 @@ class ChatUserFocus {
     return this.focused.length > 0;
   }
 
+  /** Whether `value` (a nick or a flair name) currently has a focus rule. */
+  isFocusedOn(value = '') {
+    return this.focused.includes(value.toLowerCase());
+  }
+
   addCssRule(value, isFlair) {
     let rule;
     if (isFlair) {

--- a/assets/chat/js/focus.js
+++ b/assets/chat/js/focus.js
@@ -18,7 +18,11 @@ class ChatUserFocus {
     const t = $(target);
     if (t.hasClass('chat-user')) {
       if (!this.chat.settings.get('focusmentioned')) {
-        this.toggleFocus(t.closest('.msg-user').data('username'), false, true);
+        // Keep the message the mention sits in visible as well. `.msg-chat`
+        // rather than `.msg-user`: mentions are formatted into event messages
+        // (deaths, broadcasts, donations, subscriptions) too, and those carry
+        // `data-username` without being `.msg-user`.
+        this.toggleFocus(t.closest('.msg-chat').data('username'), false, true);
       }
       this.toggleFocus(t.text());
     } else if (
@@ -35,7 +39,13 @@ class ChatUserFocus {
   }
 
   toggleFocus(value = '', isFlair = false, onlyAdd = false) {
-    const normalized = value.toLowerCase();
+    const normalized = (value ?? '').toLowerCase();
+    // A missing nick or flair would otherwise insert a rule matching nothing,
+    // leaving `isFocused()` true with the whole chat dimmed and no way back.
+    if (normalized === '') {
+      return this;
+    }
+
     const index = this.focused.indexOf(normalized);
     const focused = index !== -1;
 

--- a/assets/chat/js/focus.test.js
+++ b/assets/chat/js/focus.test.js
@@ -1,0 +1,125 @@
+// @ts-nocheck
+
+import $ from 'jquery';
+import ChatUserFocus from './focus';
+
+// Stands in for the `<style>` sheet the real chat inserts its focus rules into.
+function makeSheet() {
+  const cssRules = [];
+  return {
+    cssRules,
+    insertRule: (rule, index) => cssRules.splice(index, 0, rule),
+    deleteRule: (index) => cssRules.splice(index, 1),
+  };
+}
+
+const OUTPUT_HTML = `
+  <div id="chat-output-frame">
+    <div class="msg-chat msg-user" data-username="destiny">
+      <a class="user">Destiny</a>
+      <span class="text">yo <span class="chat-user">Cake</span></span>
+    </div>
+    <div class="msg-chat msg-death" data-username="adminandy">
+      <span class="text">
+        AdminAndy was slain by <span class="chat-user">Cake</span>
+      </span>
+    </div>
+    <div class="msg-chat msg-status">
+      <span class="text"><span class="chat-user">Cake</span> joined</span>
+    </div>
+  </div>`;
+
+function setup({ focusmentioned = false } = {}) {
+  const output = $(OUTPUT_HTML);
+  $(document.body).empty().append(output);
+
+  const sheet = makeSheet();
+  const chat = {
+    output,
+    ui: $('<div id="chat"></div>'),
+    settings: new Map([['focusmentioned', focusmentioned]]),
+  };
+  return { focus: new ChatUserFocus(chat, sheet), sheet, output, chat };
+}
+
+// The nicks a rule set covers, in insertion order.
+function focusedNicks(focus) {
+  return [...focus.focused];
+}
+
+describe('ChatUserFocus.toggleElement', () => {
+  it('also focuses the author of the message a mention sits in', () => {
+    const { focus, output } = setup();
+
+    focus.toggleElement(output.find('.msg-user .chat-user')[0]);
+
+    expect(focusedNicks(focus)).toEqual(['destiny', 'cake']);
+  });
+
+  it('focuses the author of an event message a mention sits in', () => {
+    const { focus, output } = setup();
+
+    // `.msg-death` carries `data-username` but is not a `.msg-user`, which used
+    // to leave the author lookup empty and insert a rule matching nothing.
+    focus.toggleElement(output.find('.msg-death .chat-user')[0]);
+
+    expect(focusedNicks(focus)).toEqual(['adminandy', 'cake']);
+  });
+
+  it('unfocuses cleanly when the message has no author to focus', () => {
+    const { focus, output, chat } = setup();
+    const mention = output.find('.msg-status .chat-user')[0];
+
+    focus.toggleElement(mention);
+    expect(focusedNicks(focus)).toEqual(['cake']);
+
+    focus.toggleElement(mention);
+    expect(focusedNicks(focus)).toEqual([]);
+    expect(focus.isFocused()).toBe(false);
+    expect(chat.ui.hasClass('focus')).toBe(false);
+  });
+
+  it('leaves the author alone when focusmentioned is on', () => {
+    const { focus, output } = setup({ focusmentioned: true });
+
+    focus.toggleElement(output.find('.msg-user .chat-user')[0]);
+
+    expect(focusedNicks(focus)).toEqual(['cake']);
+  });
+});
+
+describe('ChatUserFocus.toggleFocus', () => {
+  it('ignores a missing nick or flair rather than inserting a dead rule', () => {
+    const { focus, sheet } = setup();
+
+    focus.toggleFocus(undefined);
+    focus.toggleFocus(null, true);
+    focus.toggleFocus('');
+
+    expect(focusedNicks(focus)).toEqual([]);
+    expect(sheet.cssRules).toEqual([]);
+    expect(focus.isFocused()).toBe(false);
+  });
+
+  it('toggles a nick on and off, keeping the sheet in step', () => {
+    const { focus, sheet } = setup();
+
+    focus.toggleFocus('Destiny');
+    expect(focusedNicks(focus)).toEqual(['destiny']);
+    expect(sheet.cssRules).toHaveLength(1);
+    expect(focus.isFocusedOn('DESTINY')).toBe(true);
+
+    focus.toggleFocus('Destiny');
+    expect(focusedNicks(focus)).toEqual([]);
+    expect(sheet.cssRules).toEqual([]);
+  });
+
+  it('only adds when onlyAdd is set', () => {
+    const { focus } = setup();
+
+    focus.toggleFocus('destiny', false, true);
+    focus.toggleFocus('destiny', false, true);
+
+    expect(focusedNicks(focus)).toEqual(['destiny']);
+  });
+});

--- a/assets/chat/js/menus/ChatMenu.js
+++ b/assets/chat/js/menus/ChatMenu.js
@@ -56,7 +56,29 @@ export default class ChatMenu extends EventEmitter {
     }
   }
 
-  static closeMenus(chat) {
-    chat.menus.forEach((m) => m.hide());
+  /**
+   * Whether something happening elsewhere -- a click in chat, another menu
+   * opening, a resize -- dismisses this menu. The user info window is placed
+   * and dismissed deliberately, so only its close control (or ESC) hides it.
+   */
+  get closesOnOutsideInteraction() {
+    return true;
+  }
+
+  /**
+   * Hides the open menus. `all` includes the ones that only close deliberately,
+   * for ESC; `except` spares the menu containing that element, so a menu opened
+   * from inside another leaves the one it came from up.
+   */
+  static closeMenus(chat, { all = false, except = null } = {}) {
+    chat.menus.forEach((menu) => {
+      if (!all && !menu.closesOnOutsideInteraction) {
+        return;
+      }
+      if (except && menu.ui[0]?.contains(except)) {
+        return;
+      }
+      menu.hide();
+    });
   }
 }

--- a/assets/chat/js/menus/ChatMenu.test.js
+++ b/assets/chat/js/menus/ChatMenu.test.js
@@ -1,0 +1,86 @@
+// @ts-nocheck
+
+// The scroll plugin pulls in a CSS import that jest can't parse, and no fixture
+// here has a `.scrollable`. Stub it so the import chain stays JS-only.
+jest.mock('../scroll', () => ({ __esModule: true, default: class {} }));
+
+import $ from 'jquery';
+import ChatMenu from './ChatMenu';
+
+// A menu that only its own close control dismisses, the way the user info
+// window does.
+class StickyMenu extends ChatMenu {
+  get closesOnOutsideInteraction() {
+    return false;
+  }
+}
+
+function setup() {
+  const ui = $(
+    `<div id="chat">
+       <div id="ordinary" class="chat-menu"><i class="chat-menu-close"></i></div>
+       <div id="sticky" class="chat-menu"><i class="chat-menu-close"></i></div>
+     </div>`,
+  );
+  $(document.body).empty().append(ui);
+
+  const chat = { menus: new Map() };
+  const ordinary = new ChatMenu(ui.find('#ordinary'), $('<div></div>'), chat);
+  const sticky = new StickyMenu(ui.find('#sticky'), $('<div></div>'), chat);
+  chat.menus.set('ordinary', ordinary);
+  chat.menus.set('sticky', sticky);
+
+  ordinary.show();
+  sticky.show();
+
+  return { chat, ui, ordinary, sticky };
+}
+
+describe('ChatMenu.closeMenus', () => {
+  it('leaves a menu that only closes deliberately', () => {
+    const { chat, ordinary, sticky } = setup();
+
+    ChatMenu.closeMenus(chat);
+
+    expect(ordinary.visible).toBe(false);
+    expect(sticky.visible).toBe(true);
+  });
+
+  it('closes everything when asked for all of them', () => {
+    const { chat, ordinary, sticky } = setup();
+
+    ChatMenu.closeMenus(chat, { all: true });
+
+    expect(ordinary.visible).toBe(false);
+    expect(sticky.visible).toBe(false);
+  });
+
+  it('spares the menu the given element belongs to', () => {
+    const { chat, ui, ordinary } = setup();
+    const inside = $('<button></button>').appendTo(ui.find('#ordinary'))[0];
+
+    ChatMenu.closeMenus(chat, { except: inside });
+
+    expect(ordinary.visible).toBe(true);
+  });
+
+  it('still closes the menus the element is not in', () => {
+    const { chat, ui, ordinary, sticky } = setup();
+    const inside = $('<button></button>').appendTo(ui.find('#sticky'))[0];
+
+    ChatMenu.closeMenus(chat, { all: true, except: inside });
+
+    expect(ordinary.visible).toBe(false);
+    expect(sticky.visible).toBe(true);
+  });
+});
+
+describe('ChatMenu close control', () => {
+  it('hides a sticky menu when its own close control is clicked', () => {
+    const { ui, sticky } = setup();
+
+    ui.find('#sticky .chat-menu-close').trigger('click');
+
+    expect(sticky.visible).toBe(false);
+  });
+});

--- a/assets/chat/js/menus/ChatMenuFloating.js
+++ b/assets/chat/js/menus/ChatMenuFloating.js
@@ -8,50 +8,87 @@ export default class ChatMenuFloating extends ChatMenu {
     this.chat = chat;
     this.draggable = draggable;
 
-    this.mousedown = false;
-    this.x1 = 0;
-    this.x2 = 0;
-    this.y1 = 0;
-    this.y2 = 0;
+    this.dragging = false;
+    this.grabX = 0;
+    this.grabY = 0;
 
     if (this.draggable?.length) {
       this.draggable[0].style.cursor = 'grab';
-      this.draggable.on('mouseup', (e) => {
-        e.preventDefault();
-        this.mousedown = false;
-      });
-      this.draggable.on('mousedown', (e) => {
-        e.preventDefault();
-        this.mousedown = true;
-        this.x1 = e.clientX;
-        this.y1 = e.clientY;
-      });
-      this.chat.output.on('mousemove', (e) => {
-        this.drag(e);
-      });
-      this.ui.on('mousemove', (e) => {
-        this.drag(e);
-      });
+      // Without this the browser claims the gesture for panning before the
+      // first pointermove lands, which is why the menu couldn't be dragged by
+      // touch at all.
+      this.draggable[0].style.touchAction = 'none';
+
+      this.draggable.on('pointerdown', (e) => this.startDrag(e));
+      this.draggable.on('pointermove', (e) => this.drag(e));
+      this.draggable.on('pointerup pointercancel', () => this.endDrag());
     }
+  }
+
+  startDrag(e) {
+    // Ignore a second finger mid-drag, presses other than the primary button,
+    // and the menu's own close control, which lives inside the drag handle.
+    if (
+      this.dragging ||
+      e.button !== 0 ||
+      e.target.closest('.close, .chat-menu-close')
+    ) {
+      return;
+    }
+
+    // Keeps the press from starting a text selection or moving focus. Safe
+    // after the guard above: nothing else inside the handle is clickable.
+    e.preventDefault();
+
+    this.dragging = true;
+    // Where inside the menu the pointer took hold. Placing the menu from this
+    // on every move, rather than accumulating deltas, is what puts it back
+    // under the same spot after a drag has been held past a clamped edge.
+    this.grabX = e.clientX - this.ui[0].offsetLeft;
+    this.grabY = e.clientY - this.ui[0].offsetTop;
+    this.draggable[0].style.cursor = 'grabbing';
+
+    // Capturing routes every later pointermove -- and the pointerup -- back to
+    // the handle whatever ends up under the pointer. Tracking moves on the
+    // menu and the chat output instead used to work only because the menu
+    // stays glued to the pointer: a drag fast enough to overshoot it onto the
+    // input frame froze, and releasing there never cleared the drag, leaving
+    // the menu stuck to the pointer afterwards.
+    this.draggable[0].setPointerCapture(e.pointerId);
   }
 
   drag(e) {
-    if (this.mousedown) {
-      this.x2 = this.x1 - e.clientX;
-      this.y2 = this.y1 - e.clientY;
-      this.x1 = e.clientX;
-      this.y1 = e.clientY;
-
-      this.draggable[0].style.cursor = 'grabbing';
-      this.ui[0].style.left = `${this.ui[0].offsetLeft - this.x2}px`;
-      this.ui[0].style.top = `${this.ui[0].offsetTop - this.y2}px`;
-    } else {
-      this.draggable[0].style.cursor = 'grab';
+    if (!this.dragging) {
+      return;
     }
+
+    this.moveTo(e.clientX - this.grabX, e.clientY - this.grabY);
+  }
+
+  /**
+   * Places the menu, keeping the whole of it inside the box it is positioned
+   * in. The chat is embedded in an iframe on the bigscreen page and `#chat` is
+   * `overflow: hidden`, so a menu dragged past the edge is clipped out of
+   * sight -- and capturing the pointer means leaving the frame no longer ends
+   * the drag on its own. It stops at the edge instead.
+   */
+  moveTo(x, y) {
+    const menu = this.ui[0];
+    const bounds = menu.offsetParent ?? document.documentElement;
+    const maxLeft = bounds.clientWidth - menu.offsetWidth;
+    const maxTop = bounds.clientHeight - menu.offsetHeight;
+
+    menu.style.left = `${Math.max(0, Math.min(x, maxLeft))}px`;
+    menu.style.top = `${Math.max(0, Math.min(y, maxTop))}px`;
+  }
+
+  endDrag() {
+    this.dragging = false;
+    this.draggable[0].style.cursor = 'grab';
   }
 
   position(e) {
-    this.mousedown = false;
+    this.dragging = false;
     // calculating floating window location (if it doesn't fit on screen, adjusting it a bit so it does)
     const x =
       this.ui.width() + e.clientX > window.innerWidth

--- a/assets/chat/js/menus/ChatMenuFloating.js
+++ b/assets/chat/js/menus/ChatMenuFloating.js
@@ -23,6 +23,15 @@ export default class ChatMenuFloating extends ChatMenu {
       this.draggable.on('pointermove', (e) => this.drag(e));
       this.draggable.on('pointerup pointercancel', () => this.endDrag());
     }
+
+    // A menu that outlives a resize -- the bigscreen chat panel has a drag bar
+    // -- would otherwise be left outside the shrunken chat and clipped away,
+    // with its close control out of reach.
+    window.addEventListener('resize', () => {
+      if (this.visible) {
+        this.moveTo(this.ui[0].offsetLeft, this.ui[0].offsetTop);
+      }
+    });
   }
 
   startDrag(e) {

--- a/assets/chat/js/menus/ChatMenuFloating.test.js
+++ b/assets/chat/js/menus/ChatMenuFloating.test.js
@@ -1,0 +1,217 @@
+// @ts-nocheck
+
+// The scroll plugin pulls in a CSS import that jest can't parse, and the menu
+// never uses it here (no `.scrollable` in the fixture). Stub it so the import
+// chain stays JS-only.
+jest.mock('../scroll', () => ({ __esModule: true, default: class {} }));
+
+import $ from 'jquery';
+import ChatMenuFloating from './ChatMenuFloating';
+
+const MENU_HTML = `
+  <div id="floating-menu" class="chat-menu">
+    <div class="chat-menu-inner floating-window">
+      <div class="toolbar">
+        <h5><span>User Info</span> <i class="chat-menu-close"></i></h5>
+      </div>
+      <div class="body">content</div>
+    </div>
+  </div>`;
+
+// The chat the menu is positioned inside, and the menu's own size. Together
+// they leave 450x400 of room to drag into.
+const BOUNDS = { width: 800, height: 600 };
+const MENU_SIZE = { width: 350, height: 200 };
+
+function setup() {
+  const chatEl = $('<div id="chat"></div>').append(MENU_HTML)[0];
+  $(document.body).empty().append(chatEl);
+
+  const ui = $(chatEl).find('#floating-menu');
+  const menuEl = ui[0];
+  // jsdom lays nothing out, so every layout metric reads 0. Stand in for the
+  // ones the drag reads, and let `offsetLeft`/`offsetTop` reflect the inline
+  // style it writes back, the way the browser would.
+  Object.defineProperties(chatEl, {
+    clientWidth: { get: () => BOUNDS.width },
+    clientHeight: { get: () => BOUNDS.height },
+  });
+  Object.defineProperties(menuEl, {
+    offsetParent: { get: () => chatEl },
+    offsetWidth: { get: () => MENU_SIZE.width },
+    offsetHeight: { get: () => MENU_SIZE.height },
+    offsetLeft: { get: () => parseInt(menuEl.style.left, 10) || 0 },
+    offsetTop: { get: () => parseInt(menuEl.style.top, 10) || 0 },
+  });
+  menuEl.style.left = '100px';
+  menuEl.style.top = '200px';
+
+  const draggable = ui.find('.toolbar');
+  // jsdom implements no pointer capture; this stands in for it so the call can
+  // be asserted on.
+  draggable[0].setPointerCapture = jest.fn();
+
+  const chat = { output: $('<div></div>'), menus: new Map() };
+  const menu = new ChatMenuFloating(ui, $('<div></div>'), chat, draggable);
+
+  return { menu, ui, draggable, handle: draggable[0] };
+}
+
+function pointer(type, props = {}) {
+  return $.Event(type, {
+    pointerId: 1,
+    button: 0,
+    pointerType: 'touch',
+    ...props,
+  });
+}
+
+function position(ui) {
+  return { left: ui[0].style.left, top: ui[0].style.top };
+}
+
+describe('ChatMenuFloating dragging', () => {
+  it('drags by touch', () => {
+    const { ui, draggable } = setup();
+
+    draggable.trigger(pointer('pointerdown', { clientX: 150, clientY: 210 }));
+    draggable.trigger(pointer('pointermove', { clientX: 200, clientY: 260 }));
+    draggable.trigger(pointer('pointermove', { clientX: 220, clientY: 300 }));
+    draggable.trigger(pointer('pointerup', { clientX: 220, clientY: 300 }));
+
+    expect(position(ui)).toEqual({ left: '170px', top: '290px' });
+  });
+
+  it('opts the handle out of the browser panning the gesture away', () => {
+    const { handle } = setup();
+
+    expect(handle.style.touchAction).toBe('none');
+  });
+
+  it('captures the pointer so the drag cannot be outrun', () => {
+    const { draggable, handle } = setup();
+
+    draggable.trigger(pointer('pointerdown', { clientX: 150, clientY: 210 }));
+
+    expect(handle.setPointerCapture).toHaveBeenCalledWith(1);
+  });
+
+  it('keeps tracking a move that lands far outside the menu', () => {
+    const { ui, draggable } = setup();
+
+    draggable.trigger(pointer('pointerdown', { clientX: 150, clientY: 210 }));
+    // The overshoot that used to freeze the drag: one jump past the menu, onto
+    // the input frame. Capture routes it back to the handle regardless -- the
+    // menu follows as far as the bottom edge lets it.
+    draggable.trigger(pointer('pointermove', { clientX: 150, clientY: 1000 }));
+
+    expect(position(ui)).toEqual({ left: '100px', top: '400px' });
+  });
+
+  it('stops at the far edges of the chat rather than leaving it', () => {
+    const { ui, draggable } = setup();
+
+    draggable.trigger(pointer('pointerdown', { clientX: 150, clientY: 210 }));
+    // The chat is an iframe on the bigscreen page and clips its overflow, so a
+    // menu dragged out of it would be invisible.
+    draggable.trigger(pointer('pointermove', { clientX: 5000, clientY: 5000 }));
+
+    expect(position(ui)).toEqual({ left: '450px', top: '400px' });
+  });
+
+  it('stops at the near edges of the chat', () => {
+    const { ui, draggable } = setup();
+
+    draggable.trigger(pointer('pointerdown', { clientX: 150, clientY: 210 }));
+    draggable.trigger(
+      pointer('pointermove', { clientX: -5000, clientY: -5000 }),
+    );
+
+    expect(position(ui)).toEqual({ left: '0px', top: '0px' });
+  });
+
+  it('comes back under the grab point after being held past an edge', () => {
+    const { ui, draggable } = setup();
+
+    draggable.trigger(pointer('pointerdown', { clientX: 150, clientY: 210 }));
+    draggable.trigger(pointer('pointermove', { clientX: 5000, clientY: 5000 }));
+    draggable.trigger(pointer('pointermove', { clientX: 150, clientY: 210 }));
+
+    expect(position(ui)).toEqual({ left: '100px', top: '200px' });
+  });
+
+  it('stops dragging once the pointer is released', () => {
+    const { ui, draggable } = setup();
+
+    draggable.trigger(pointer('pointerdown', { clientX: 150, clientY: 210 }));
+    draggable.trigger(pointer('pointermove', { clientX: 150, clientY: 1000 }));
+    draggable.trigger(pointer('pointerup', { clientX: 150, clientY: 1000 }));
+
+    const dropped = position(ui);
+    draggable.trigger(pointer('pointermove', { clientX: 600, clientY: 400 }));
+
+    expect(position(ui)).toEqual(dropped);
+  });
+
+  it('stops dragging when the gesture is cancelled', () => {
+    const { menu, ui, draggable } = setup();
+
+    draggable.trigger(pointer('pointerdown', { clientX: 150, clientY: 210 }));
+    draggable.trigger(pointer('pointercancel'));
+
+    const dropped = position(ui);
+    draggable.trigger(pointer('pointermove', { clientX: 600, clientY: 400 }));
+
+    expect(menu.dragging).toBe(false);
+    expect(position(ui)).toEqual(dropped);
+  });
+
+  it('leaves the close control clickable instead of dragging from it', () => {
+    const { menu, ui, draggable, handle } = setup();
+
+    ui.find('.chat-menu-close').trigger(
+      pointer('pointerdown', { clientX: 150, clientY: 210 }),
+    );
+    draggable.trigger(pointer('pointermove', { clientX: 300, clientY: 400 }));
+
+    expect(menu.dragging).toBe(false);
+    expect(handle.setPointerCapture).not.toHaveBeenCalled();
+    expect(position(ui)).toEqual({ left: '100px', top: '200px' });
+  });
+
+  it('ignores a non-primary button', () => {
+    const { menu, ui, draggable } = setup();
+
+    draggable.trigger(
+      pointer('pointerdown', { button: 2, clientX: 150, clientY: 210 }),
+    );
+    draggable.trigger(pointer('pointermove', { clientX: 300, clientY: 400 }));
+
+    expect(menu.dragging).toBe(false);
+    expect(position(ui)).toEqual({ left: '100px', top: '200px' });
+  });
+
+  it('ignores a second finger landing mid-drag', () => {
+    const { ui, draggable } = setup();
+
+    draggable.trigger(pointer('pointerdown', { clientX: 150, clientY: 210 }));
+    // A second touch must not re-anchor the drag origin, which would make the
+    // next move jump by the distance between the two fingers.
+    draggable.trigger(
+      pointer('pointerdown', { pointerId: 2, clientX: 400, clientY: 500 }),
+    );
+    draggable.trigger(pointer('pointermove', { clientX: 160, clientY: 220 }));
+
+    expect(position(ui)).toEqual({ left: '110px', top: '210px' });
+  });
+
+  it('shows the grab cursor again after a drag', () => {
+    const { draggable, handle } = setup();
+
+    draggable.trigger(pointer('pointerdown', { clientX: 150, clientY: 210 }));
+    expect(handle.style.cursor).toBe('grabbing');
+
+    draggable.trigger(pointer('pointerup', { clientX: 150, clientY: 210 }));
+    expect(handle.style.cursor).toBe('grab');
+  });
+});

--- a/assets/chat/js/menus/ChatUserActionMenu.js
+++ b/assets/chat/js/menus/ChatUserActionMenu.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
-import ChatMenu from './ChatMenu';
 import ChatMenuFloating from './ChatMenuFloating';
 
 /**
- * The dropdown shown when a username is left-clicked in chat.
+ * The dropdown shown when a username is left-clicked, either in chat or in the
+ * user list.
  *
  * Left-clicking a name used to highlight that user's messages outright, which
  * left the user-info menu behind a right-click — unreachable on touch devices
@@ -14,9 +14,9 @@ export default class ChatUserActionMenu extends ChatMenuFloating {
   constructor(ui, btn, chat) {
     super(ui, btn, chat);
 
-    /** The `.user` / `.chat-user` element the menu was opened from. */
+    /** The element the menu was opened from, whose text is the nick. */
     this.usernameElement = null;
-    /** The `.msg-chat` the clicked username belongs to. */
+    /** What the user info menu reads its content out of. See `openMenu`. */
     this.message = null;
     this.clickedNick = '';
 
@@ -24,7 +24,7 @@ export default class ChatUserActionMenu extends ChatMenuFloating {
 
     // Layouts without the menu markup (the on-stream overlay, the vote chat)
     // keep the old behavior — the click falls through to `ChatUserFocus`.
-    if (this.ui.length) {
+    if (this.available) {
       this.chat.output.on(
         'click',
         '.msg-chat .user, .msg-chat .chat-user',
@@ -34,6 +34,11 @@ export default class ChatUserActionMenu extends ChatMenuFloating {
 
     this.ui.on('click', '#highlight-user-button', () => this.highlightUser());
     this.ui.on('click', '#user-info-button', (e) => this.showUserInfo(e));
+  }
+
+  /** Whether this layout ships the menu's markup. */
+  get available() {
+    return this.ui.length > 0;
   }
 
   onUsernameClick(e) {
@@ -56,7 +61,7 @@ export default class ChatUserActionMenu extends ChatMenuFloating {
       return undefined;
     }
 
-    this.openMenu(e);
+    this.openMenu(e, e.currentTarget, $(e.currentTarget).closest('.msg-chat'));
 
     // Returning false stops the click reaching `ChatUserFocus`, which is bound
     // directly to the output and would otherwise clear the current highlight.
@@ -64,21 +69,34 @@ export default class ChatUserActionMenu extends ChatMenuFloating {
     return false;
   }
 
-  openMenu(e) {
+  /**
+   * `usernameElement` is the element whose text is the nick — a `.user` link
+   * or `.chat-user` mention in chat, the `.user` span of a user list entry.
+   * `container` is what the user info menu reads the clicked user's message and
+   * flairs out of: the surrounding `.msg-chat`, or the `.user-entry` itself.
+   */
+  openMenu(e, usernameElement, container) {
     // Clicking the same name again dismisses the menu.
     const openForSameUsername =
-      this.visible && this.usernameElement === e.currentTarget;
+      this.visible && this.usernameElement === usernameElement;
 
-    ChatMenu.closeMenus(this.chat);
+    // Close the other menus — but not one the click came from, so opening this
+    // off a user list entry leaves the list up behind it.
+    this.chat.menus.forEach((menu) => {
+      if (!menu.ui[0]?.contains(e.currentTarget)) {
+        menu.hide();
+      }
+    });
+
     if (openForSameUsername) {
       return;
     }
 
-    this.usernameElement = e.currentTarget;
-    this.message = $(e.currentTarget).closest('.msg-chat');
+    this.usernameElement = usernameElement;
+    this.message = container;
     // `textContent` rather than `innerText` so the nick matches the one
     // `ChatUserFocus` keys its highlight rules on.
-    this.clickedNick = e.currentTarget.textContent;
+    this.clickedNick = usernameElement.textContent;
 
     this.highlightButton.text(
       this.chat.userfocus.isFocusedOn(this.clickedNick)

--- a/assets/chat/js/menus/ChatUserActionMenu.js
+++ b/assets/chat/js/menus/ChatUserActionMenu.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import ChatMenu from './ChatMenu';
 import ChatMenuFloating from './ChatMenuFloating';
 
 /**
@@ -82,11 +83,7 @@ export default class ChatUserActionMenu extends ChatMenuFloating {
 
     // Close the other menus — but not one the click came from, so opening this
     // off a user list entry leaves the list up behind it.
-    this.chat.menus.forEach((menu) => {
-      if (!menu.ui[0]?.contains(e.currentTarget)) {
-        menu.hide();
-      }
-    });
+    ChatMenu.closeMenus(this.chat, { except: e.currentTarget });
 
     if (openForSameUsername) {
       return;

--- a/assets/chat/js/menus/ChatUserActionMenu.js
+++ b/assets/chat/js/menus/ChatUserActionMenu.js
@@ -1,0 +1,105 @@
+import $ from 'jquery';
+import ChatMenu from './ChatMenu';
+import ChatMenuFloating from './ChatMenuFloating';
+
+/**
+ * The dropdown shown when a username is left-clicked in chat.
+ *
+ * Left-clicking a name used to highlight that user's messages outright, which
+ * left the user-info menu behind a right-click — unreachable on touch devices
+ * and easy to never discover. Both actions now live behind the gesture people
+ * reach for first.
+ */
+export default class ChatUserActionMenu extends ChatMenuFloating {
+  constructor(ui, btn, chat) {
+    super(ui, btn, chat);
+
+    /** The `.user` / `.chat-user` element the menu was opened from. */
+    this.usernameElement = null;
+    /** The `.msg-chat` the clicked username belongs to. */
+    this.message = null;
+    this.clickedNick = '';
+
+    this.highlightButton = this.ui.find('#highlight-user-button');
+
+    // Layouts without the menu markup (the on-stream overlay, the vote chat)
+    // keep the old behavior — the click falls through to `ChatUserFocus`.
+    if (this.ui.length) {
+      this.chat.output.on(
+        'click',
+        '.msg-chat .user, .msg-chat .chat-user',
+        (e) => this.onUsernameClick(e),
+      );
+    }
+
+    this.ui.on('click', '#highlight-user-button', () => this.highlightUser());
+    this.ui.on('click', '#user-info-button', (e) => this.showUserInfo(e));
+  }
+
+  onUsernameClick(e) {
+    const username = e.currentTarget;
+
+    // `tier` is a sub-tier label styled to match the sub's username color
+    // (which requires the `user` class), and `non-chat-user` marks a user-like
+    // reference that isn't a chat user (e.g. an X handle on an XPOST event).
+    // Neither one has anything to act on.
+    if (
+      username.classList.contains('tier') ||
+      username.classList.contains('non-chat-user')
+    ) {
+      return undefined;
+    }
+
+    // Clicking the author of a whisper opens the conversation with them (see
+    // `chat.js`), so leave that click alone.
+    if (username.matches('a.user') && username.closest('.msg-whisper')) {
+      return undefined;
+    }
+
+    this.openMenu(e);
+
+    // Returning false stops the click reaching `ChatUserFocus`, which is bound
+    // directly to the output and would otherwise clear the current highlight.
+    // jQuery runs delegated handlers before direct ones, so this wins.
+    return false;
+  }
+
+  openMenu(e) {
+    // Clicking the same name again dismisses the menu.
+    const openForSameUsername =
+      this.visible && this.usernameElement === e.currentTarget;
+
+    ChatMenu.closeMenus(this.chat);
+    if (openForSameUsername) {
+      return;
+    }
+
+    this.usernameElement = e.currentTarget;
+    this.message = $(e.currentTarget).closest('.msg-chat');
+    // `textContent` rather than `innerText` so the nick matches the one
+    // `ChatUserFocus` keys its highlight rules on.
+    this.clickedNick = e.currentTarget.textContent;
+
+    this.highlightButton.text(
+      this.chat.userfocus.isFocusedOn(this.clickedNick)
+        ? 'Remove highlight'
+        : 'Highlight',
+    );
+
+    this.position(e);
+    this.show();
+  }
+
+  highlightUser() {
+    // Handing the element over (rather than the nick) keeps the mention-vs-
+    // author distinction `ChatUserFocus` makes when `focusmentioned` is off.
+    this.chat.userfocus.toggleElement(this.usernameElement);
+    this.hide();
+  }
+
+  showUserInfo(e) {
+    const userInfoMenu = this.chat.menus.get('user-info');
+    this.hide();
+    userInfoMenu?.showUser(e, this.message, this.clickedNick.toLowerCase());
+  }
+}

--- a/assets/chat/js/menus/ChatUserActionMenu.test.js
+++ b/assets/chat/js/menus/ChatUserActionMenu.test.js
@@ -1,0 +1,167 @@
+// @ts-nocheck
+
+// The scroll plugin pulls in a CSS import that jest can't parse, and this menu
+// never uses it (no `.scrollable` in the fixture). Stub it so the import chain
+// stays JS-only.
+jest.mock('../scroll', () => ({ __esModule: true, default: class {} }));
+
+import $ from 'jquery';
+import ChatUserActionMenu from './ChatUserActionMenu';
+
+const MENU_HTML = `
+  <div id="user-action-menu" class="chat-menu">
+    <div class="chat-menu-inner floating-window">
+      <button id="highlight-user-button" class="user-action">Highlight</button>
+      <button id="user-info-button" class="user-action">User info</button>
+    </div>
+  </div>`;
+
+const OUTPUT_HTML = `
+  <div id="chat-output-frame">
+    <div class="msg-chat msg-user" data-username="destiny">
+      <a class="user">Destiny</a>
+      <span class="text">yo <span class="chat-user">Cake</span></span>
+    </div>
+    <div class="msg-chat msg-user" data-username="rain">
+      <a class="user tier">Tier 3</a>
+      <a class="user non-chat-user">@elonmusk</a>
+    </div>
+    <div class="msg-chat msg-user msg-whisper" data-username="cake">
+      <a class="user">Cake</a>
+      <span class="text">hey</span>
+    </div>
+  </div>`;
+
+function setup({ focused = [] } = {}) {
+  const ui = $(MENU_HTML);
+  const output = $(OUTPUT_HTML);
+  $(document.body).empty().append(output).append(ui);
+
+  const userfocus = {
+    toggleElement: jest.fn(),
+    isFocusedOn: (value) => focused.includes(value.toLowerCase()),
+  };
+  const userInfoMenu = { showUser: jest.fn(), hide: jest.fn() };
+
+  const chat = { output, userfocus, menus: new Map() };
+  const menu = new ChatUserActionMenu(ui, $('<div></div>'), chat);
+  chat.menus.set('user-info', userInfoMenu);
+  chat.menus.set('user-action', menu);
+
+  return { menu, ui, output, userfocus, userInfoMenu };
+}
+
+function clickUsername(output, selector) {
+  output.find(selector).trigger($.Event('click', { clientX: 10, clientY: 10 }));
+}
+
+describe('ChatUserActionMenu', () => {
+  it('opens on a left click on a message author, offering both actions', () => {
+    const { menu, ui, output } = setup();
+
+    clickUsername(output, '.msg-user:first .user');
+
+    expect(menu.visible).toBe(true);
+    expect(ui.hasClass('active')).toBe(true);
+    expect(ui.find('#highlight-user-button').text()).toBe('Highlight');
+    expect(ui.find('#user-info-button').text()).toBe('User info');
+    expect(menu.clickedNick).toBe('Destiny');
+  });
+
+  it('opens on a left click on an in-text mention', () => {
+    const { menu, output } = setup();
+
+    clickUsername(output, '.chat-user');
+
+    expect(menu.visible).toBe(true);
+    expect(menu.clickedNick).toBe('Cake');
+    expect(menu.message.data('username')).toBe('destiny');
+  });
+
+  it('stops the click reaching the highlight-clearing output handler', () => {
+    const { output } = setup();
+    const outputClick = jest.fn();
+    output.on('click', outputClick);
+
+    clickUsername(output, '.msg-user:first .user');
+
+    expect(outputClick).not.toHaveBeenCalled();
+  });
+
+  it('labels the highlight action as a removal when already highlighted', () => {
+    const { ui, output } = setup({ focused: ['destiny'] });
+
+    clickUsername(output, '.msg-user:first .user');
+
+    expect(ui.find('#highlight-user-button').text()).toBe('Remove highlight');
+  });
+
+  it('hands the clicked element to the focus handler and closes', () => {
+    const { menu, ui, output, userfocus } = setup();
+
+    clickUsername(output, '.msg-user:first .user');
+    ui.find('#highlight-user-button').trigger('click');
+
+    expect(userfocus.toggleElement).toHaveBeenCalledWith(
+      output.find('.msg-user:first .user')[0],
+    );
+    expect(menu.visible).toBe(false);
+  });
+
+  it('opens the user info menu for the clicked nick and closes', () => {
+    const { menu, ui, output, userInfoMenu } = setup();
+
+    clickUsername(output, '.chat-user');
+    ui.find('#user-info-button').trigger('click');
+
+    expect(userInfoMenu.showUser).toHaveBeenCalledTimes(1);
+    const [, message, nick] = userInfoMenu.showUser.mock.calls[0];
+    expect(nick).toBe('cake');
+    expect(message.data('username')).toBe('destiny');
+    expect(menu.visible).toBe(false);
+  });
+
+  it('closes when the same username is clicked again', () => {
+    const { menu, output } = setup();
+
+    clickUsername(output, '.msg-user:first .user');
+    clickUsername(output, '.msg-user:first .user');
+
+    expect(menu.visible).toBe(false);
+  });
+
+  it('ignores sub-tier labels and non-chat users', () => {
+    const { menu, output } = setup();
+
+    clickUsername(output, '.tier');
+    expect(menu.visible).toBe(false);
+
+    clickUsername(output, '.non-chat-user');
+    expect(menu.visible).toBe(false);
+  });
+
+  it('leaves whisper authors to the open-conversation handler', () => {
+    const { menu, output } = setup();
+
+    clickUsername(output, '.msg-whisper .user');
+
+    expect(menu.visible).toBe(false);
+  });
+
+  it('leaves username clicks alone when the menu markup is absent', () => {
+    const output = $(OUTPUT_HTML);
+    $(document.body).empty().append(output);
+    const outputClick = jest.fn();
+    const chat = {
+      output,
+      userfocus: { toggleElement: jest.fn(), isFocusedOn: () => false },
+      menus: new Map(),
+    };
+
+    new ChatUserActionMenu($(), $('<div></div>'), chat);
+    output.on('click', outputClick);
+    clickUsername(output, '.msg-user:first .user');
+
+    expect(outputClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assets/chat/js/menus/ChatUserActionMenu.test.js
+++ b/assets/chat/js/menus/ChatUserActionMenu.test.js
@@ -41,8 +41,10 @@ function setup({ focused = [] } = {}) {
     toggleElement: jest.fn(),
     isFocusedOn: (value) => focused.includes(value.toLowerCase()),
   };
+  // Mirrors the real user info menu, which only its own close control hides.
   const userInfoMenu = {
     ui: $('<div id="chat-user-info"></div>'),
+    closesOnOutsideInteraction: false,
     showUser: jest.fn(),
     hide: jest.fn(),
   };
@@ -164,7 +166,11 @@ describe('ChatUserActionMenu', () => {
     // Stand in for the user list: a menu whose ui contains the clicked entry.
     const list = $('<div id="chat-user-list"></div>').append(USER_ENTRY_HTML);
     $(document.body).append(list);
-    const listMenu = { ui: list, hide: jest.fn() };
+    const listMenu = {
+      ui: list,
+      closesOnOutsideInteraction: true,
+      hide: jest.fn(),
+    };
     menu.chat.menus.set('users', listMenu);
 
     const entry = list.find('.user-entry')[0];
@@ -178,7 +184,22 @@ describe('ChatUserActionMenu', () => {
     expect(ui.find('#highlight-user-button').text()).toBe('Highlight');
     expect(menu.clickedNick).toBe('Destiny');
     expect(listMenu.hide).not.toHaveBeenCalled();
-    expect(userInfoMenu.hide).toHaveBeenCalled();
+    // Nor the user info window, which a click elsewhere never dismisses.
+    expect(userInfoMenu.hide).not.toHaveBeenCalled();
+  });
+
+  it('closes the other menus it opens over', () => {
+    const { menu, output } = setup();
+    const emotes = {
+      ui: $('<div id="chat-emote-list"></div>'),
+      closesOnOutsideInteraction: true,
+      hide: jest.fn(),
+    };
+    menu.chat.menus.set('emotes', emotes);
+
+    clickUsername(output, '.msg-user:first .user');
+
+    expect(emotes.hide).toHaveBeenCalled();
   });
 
   it('reports whether the layout ships its markup', () => {

--- a/assets/chat/js/menus/ChatUserActionMenu.test.js
+++ b/assets/chat/js/menus/ChatUserActionMenu.test.js
@@ -41,7 +41,11 @@ function setup({ focused = [] } = {}) {
     toggleElement: jest.fn(),
     isFocusedOn: (value) => focused.includes(value.toLowerCase()),
   };
-  const userInfoMenu = { showUser: jest.fn(), hide: jest.fn() };
+  const userInfoMenu = {
+    ui: $('<div id="chat-user-info"></div>'),
+    showUser: jest.fn(),
+    hide: jest.fn(),
+  };
 
   const chat = { output, userfocus, menus: new Map() };
   const menu = new ChatUserActionMenu(ui, $('<div></div>'), chat);
@@ -54,6 +58,13 @@ function setup({ focused = [] } = {}) {
 function clickUsername(output, selector) {
   output.find(selector).trigger($.Event('click', { clientX: 10, clientY: 10 }));
 }
+
+// A user list entry, which `ChatUserMenu` hands to `openMenu` directly.
+const USER_ENTRY_HTML = `
+  <div class="user-entry" data-username="destiny">
+    <span class="user flair13">Destiny</span>
+    <div class="user-actions"><i class="whisper-nick"></i></div>
+  </div>`;
 
 describe('ChatUserActionMenu', () => {
   it('opens on a left click on a message author, offering both actions', () => {
@@ -146,6 +157,37 @@ describe('ChatUserActionMenu', () => {
     clickUsername(output, '.msg-whisper .user');
 
     expect(menu.visible).toBe(false);
+  });
+
+  it('opens for a user list entry, keeping the list it was opened from', () => {
+    const { menu, ui, userInfoMenu } = setup();
+    // Stand in for the user list: a menu whose ui contains the clicked entry.
+    const list = $('<div id="chat-user-list"></div>').append(USER_ENTRY_HTML);
+    $(document.body).append(list);
+    const listMenu = { ui: list, hide: jest.fn() };
+    menu.chat.menus.set('users', listMenu);
+
+    const entry = list.find('.user-entry')[0];
+    menu.openMenu(
+      $.Event('click', { currentTarget: entry, clientX: 10, clientY: 10 }),
+      entry.querySelector('.user'),
+      $(entry),
+    );
+
+    expect(menu.visible).toBe(true);
+    expect(ui.find('#highlight-user-button').text()).toBe('Highlight');
+    expect(menu.clickedNick).toBe('Destiny');
+    expect(listMenu.hide).not.toHaveBeenCalled();
+    expect(userInfoMenu.hide).toHaveBeenCalled();
+  });
+
+  it('reports whether the layout ships its markup', () => {
+    const { menu } = setup();
+
+    expect(menu.available).toBe(true);
+    expect(
+      new ChatUserActionMenu($(), $('<div></div>'), menu.chat).available,
+    ).toBe(false);
   });
 
   it('leaves username clicks alone when the menu markup is absent', () => {

--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -115,6 +115,13 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     this.chat.source.on('MSG', this.handleNewMessage.bind(this));
   }
 
+  // Dismissed only by its own close control or ESC. It is a window the user
+  // places where they want it, often to read alongside chat, so a click in
+  // chat or another menu opening shouldn't take it away.
+  get closesOnOutsideInteraction() {
+    return false;
+  }
+
   /**
    * `nick` defaults to the text of the clicked element, which is right when the
    * menu is opened straight off a username. Callers that open it from somewhere

--- a/assets/chat/js/menus/ChatUserInfoMenu.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.js
@@ -115,8 +115,13 @@ export default class ChatUserInfoMenu extends ChatMenuFloating {
     this.chat.source.on('MSG', this.handleNewMessage.bind(this));
   }
 
-  showUser(e, message) {
-    this.clickedNick = e.currentTarget.innerText.toLowerCase();
+  /**
+   * `nick` defaults to the text of the clicked element, which is right when the
+   * menu is opened straight off a username. Callers that open it from somewhere
+   * else — the user action menu's "User info" button — pass the nick explicitly.
+   */
+  showUser(e, message, nick = e.currentTarget.innerText.toLowerCase()) {
+    this.clickedNick = nick;
 
     this.setActionsVisibility();
     this.addContent(message);

--- a/assets/chat/js/menus/ChatUserInfoMenu.test.js
+++ b/assets/chat/js/menus/ChatUserInfoMenu.test.js
@@ -6,6 +6,7 @@
 jest.mock('../scroll', () => ({ __esModule: true, default: class {} }));
 
 import $ from 'jquery';
+import ChatMenu from './ChatMenu';
 import ChatUserInfoMenu from './ChatUserInfoMenu';
 import ChatUser from '../user';
 
@@ -41,6 +42,21 @@ function makeMenu() {
   const menu = new ChatUserInfoMenu(ui, $('<div></div>'), chat);
   return { menu, ui };
 }
+
+describe('ChatUserInfoMenu dismissal', () => {
+  it('is not closed by an interaction elsewhere', () => {
+    const { menu } = makeMenu();
+    const chat = { menus: new Map([['user-info', menu]]) };
+    menu.show();
+
+    ChatMenu.closeMenus(chat);
+    expect(menu.visible).toBe(true);
+
+    // Its own close control still hides it, and so does ESC.
+    ChatMenu.closeMenus(chat, { all: true });
+    expect(menu.visible).toBe(false);
+  });
+});
 
 describe('ChatUserInfoMenu.renderUserDetails', () => {
   it('renders age, gender, and bio with mapped labels when set', () => {

--- a/assets/chat/js/menus/ChatUserMenu.js
+++ b/assets/chat/js/menus/ChatUserMenu.js
@@ -47,11 +47,23 @@ export default class ChatUserMenu extends ChatMenu {
     this.searchinput = this.ui.find(
       '#chat-user-list-search .form-control:first',
     );
-    this.container.on('click', '.user-entry', (e) =>
+    this.container.on('click', '.user-entry', (e) => {
+      // Same reasoning as in chat: a left click opens the menu so the user info
+      // menu isn't stranded behind a right click. Layouts without the menu's
+      // markup fall back to highlighting outright.
+      const userAction = this.chat.menus.get('user-action');
+      if (userAction?.available) {
+        userAction.openMenu(
+          e,
+          e.currentTarget.querySelector('.user'),
+          $(e.currentTarget),
+        );
+        return;
+      }
       this.chat.userfocus.toggleFocus(
         e.currentTarget.getAttribute('data-username'),
-      ),
-    );
+      );
+    });
     this.container.on('click', '.flair', (e) =>
       this.chat.userfocus.toggleFocus(
         e.target.getAttribute('data-flair'),

--- a/assets/chat/js/menus/ChatUserMenu.test.js
+++ b/assets/chat/js/menus/ChatUserMenu.test.js
@@ -1,0 +1,82 @@
+// @ts-nocheck
+
+// The scroll plugin pulls in a CSS import that jest can't parse, and the menu
+// never uses it here (no `.scrollable` in the fixture). Stub it so the import
+// chain stays JS-only.
+jest.mock('../scroll', () => ({ __esModule: true, default: class {} }));
+
+import $ from 'jquery';
+import ChatUserMenu from './ChatUserMenu';
+
+const MENU_HTML = `
+  <div id="chat-user-list">
+    <div class="toolbar"><h5><span></span></h5></div>
+    <div class="content"></div>
+    <div id="chat-user-list-search"><input class="form-control" /></div>
+  </div>`;
+
+const USER_ENTRY_HTML = `
+  <div class="user-entry" data-username="destiny" data-user-id="1">
+    <span class="user flair13">Destiny</span>
+    <div class="user-actions"><i class="whisper-nick"></i></div>
+  </div>`;
+
+function setup({ userAction } = {}) {
+  const ui = $(MENU_HTML);
+  $(document.body).empty().append(ui);
+
+  const userfocus = { toggleFocus: jest.fn() };
+  const chat = {
+    source: { on: () => {} },
+    menus: new Map(),
+    flairsMap: new Map(),
+    isDesktop: false,
+    userfocus,
+  };
+  const menu = new ChatUserMenu(ui, $('<div></div>'), chat);
+  if (userAction) {
+    chat.menus.set('user-action', userAction);
+  }
+
+  const entry = $(USER_ENTRY_HTML);
+  ui.find('.content:first').append(entry);
+
+  return { menu, ui, entry, userfocus };
+}
+
+function clickEntry(entry) {
+  entry.trigger($.Event('click', { clientX: 10, clientY: 10 }));
+}
+
+describe('ChatUserMenu user entry clicks', () => {
+  it('opens the user action menu on the entry it was clicked in', () => {
+    const userAction = { available: true, openMenu: jest.fn() };
+    const { entry, userfocus } = setup({ userAction });
+
+    clickEntry(entry);
+
+    expect(userfocus.toggleFocus).not.toHaveBeenCalled();
+    expect(userAction.openMenu).toHaveBeenCalledTimes(1);
+    const [, usernameElement, container] = userAction.openMenu.mock.calls[0];
+    expect(usernameElement).toBe(entry.find('.user')[0]);
+    expect(container[0]).toBe(entry[0]);
+  });
+
+  it('highlights outright when the action menu markup is absent', () => {
+    const userAction = { available: false, openMenu: jest.fn() };
+    const { entry, userfocus } = setup({ userAction });
+
+    clickEntry(entry);
+
+    expect(userAction.openMenu).not.toHaveBeenCalled();
+    expect(userfocus.toggleFocus).toHaveBeenCalledWith('destiny');
+  });
+
+  it('highlights outright when there is no action menu at all', () => {
+    const { entry, userfocus } = setup();
+
+    clickEntry(entry);
+
+    expect(userfocus.toggleFocus).toHaveBeenCalledWith('destiny');
+  });
+});

--- a/assets/chat/js/menus/index.js
+++ b/assets/chat/js/menus/index.js
@@ -6,3 +6,4 @@ export { default as ChatEmoteTooltip } from './ChatEmoteTooltip';
 export { default as ChatWhisperUsers } from './ChatWhisperUsers';
 export { default as ChatUserInfoMenu } from './ChatUserInfoMenu';
 export { default as ChatEventActionMenu } from './ChatEventActionMenu';
+export { default as ChatUserActionMenu } from './ChatUserActionMenu';

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -459,6 +459,13 @@
     </div>
   </div>
 
+  <div id="user-action-menu" class="chat-menu">
+    <div class="chat-menu-inner floating-window">
+      <button id="highlight-user-button" class="user-action">Highlight</button>
+      <button id="user-info-button" class="user-action">User info</button>
+    </div>
+  </div>
+
   <div id="event-action-menu" class="chat-menu">
     <div class="chat-menu-inner floating-window">
       <button id="remove-event-button" class="event-action">


### PR DESCRIPTION
Left-clicking a username highlighted that user's messages outright, which left
the user info menu behind a right-click — unreachable on touch devices, and easy
to never discover on desktop. Other chat platforms open a menu on left click, and
left-clicking a name is the gesture people reach for first.

A left click now opens a small menu offering **Highlight** and **User info**, in
chat and in the user list. Right-click still opens the user info menu directly.

The remaining commits are fixes found while building it.

## Commits

| | |
|---|---|
| `fe67b38` | Open a menu when a username in chat is left-clicked |
| `cb17f5c` | Open the same menu from the user list |
| `142d685` | Focus the right author when a mention is in an event message |
| `55aac9f` | Drag floating menus with pointer events |
| `b6968dc` | Dismiss the user info window only on request |

### The menu

Highlight hands the clicked element to `ChatUserFocus.toggleElement()` rather than
the nick, so the mention-vs-author distinction `focus.js` makes when
`focusmentioned` is off survives intact. Its label reads *Remove highlight* when
that user is already highlighted — the underlying function is a toggle, and a
static label that sometimes un-highlights reads as a bug.

Deliberately unchanged: clicking a whisper author still opens the conversation,
clicking a flair still toggles flair focus, clicking elsewhere still clears the
highlight, and `.tier` labels and X handles are ignored. Layouts without the
menu's markup — the on-stream overlay, the vote chat — keep click-to-highlight.

Opening from the user list leaves the list up behind the menu, so Highlight
doesn't cost you your place in it. Opening from chat still closes the list, which
overlays chat anyway.

### `focus.js` fix

Clicking an `@mention` looked its message up with `closest('.msg-user')` so the
message stays visible alongside the mentioned user. Mentions are formatted into
event messages too — deaths, broadcasts, donations — and those are `.msg-chat`
without being `.msg-user`, so the lookup came back empty and
`toggleFocus(undefined)` inserted a rule matching `[data-username=""]`.

Not cosmetic: unfocusing afterwards left `''` behind, so `isFocused()` stayed
true and the chat stayed dimmed with nobody highlighted.

### Dragging

`ChatMenuFloating` was bound to `mousedown`/`mousemove`/`mouseup`, so dragging
the user info window had never worked by touch — touchscreens never synthesise
`mousemove` mid-gesture. Pointer events cover mouse, touch and pen in one path;
the handle also needs `touch-action: none` or the browser claims the gesture for
panning first.

Capturing the pointer fixes a second bug: `mousemove` is sampled, so a flick fast
enough to overshoot the menu could land on the input frame where nothing was
listening, and releasing there never cleared the drag — leaving the menu stuck to
the pointer with no button held.

Capture also removed the accident that stopped a drag at the edge of the embedded
chat on bigscreen, so the menu is now clamped to the box it's positioned in
deliberately. Floating menus re-clamp on resize as well, since the bigscreen chat
panel has a drag bar.

### Dismissal

Any click outside the user info window closed it — chat, the tools strip, another
menu opening, a resize, the tab losing focus. It's a window the reader places
where they want it, so only its own close control and ESC hide it now. The rule
lives in `closeMenus` rather than its nine callers; menus answer
`closesOnOutsideInteraction`, which the user info menu is alone in denying.

## Testing

322 unit tests across 19 suites, 66 of them new. The regression fixes were
checked against the pre-fix code first: 3 of 7 in `focus.test.js` and 9 of 13 in
`ChatMenuFloating.test.js` fail without their fix.

Also driven in the browser against the mock chat, including a bigscreen-shaped
layout (stream panel plus a same-origin chat iframe) for the clamping, and real
mouse input for the drag — `setPointerCapture` throws on a synthetic pointer id,
so unit tests alone can't prove that call is safe.

**Not verified:** a genuine *touch* drag. The touch path is covered by unit tests
and the mechanism, but I couldn't drive real touch input — worth a minute in
device mode before merging.

## Notes

- The formatting check fails on `typings/globals/{jquery,moment}/index.d.ts`.
  That reproduces on `master` unchanged, so it is pre-existing and not from this
  branch. Happy to fix it separately.
- The website picks this up via the `dgg-chat-gui` npm package, so it needs a
  version bump and publish to reach the site.
