### PR TITLE
Cap the height of a poll and scroll its options

### DIFF
--- a/assets/chat/css/menus/_poll.scss
+++ b/assets/chat/css/menus/_poll.scss
@@ -1,13 +1,20 @@
+@use 'sass:color';
 @use '../abstracts/' as a;
+
+$poll-background: #2f2f2f;
 
 #chat-poll-frame {
   display: none;
+  flex-direction: column;
   transform: translateY(-100%);
   transition: transform 250ms ease-out;
+  // Never let a poll with a lot of options swallow the chat behind it. This
+  // resolves against #chat, which is a flex column of a known height.
+  max-height: 40%;
 
   &.active {
     transform: translateY(0);
-    display: block;
+    display: flex;
   }
 
   &:not(.poll-completed) {
@@ -45,8 +52,11 @@
 }
 
 .poll-frame {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
   padding: 0.5em 0.75em;
-  background: #2f2f2f;
+  background: $poll-background;
   border-radius: 4px;
   margin: 4px;
   color: a.$text-color;
@@ -112,6 +122,93 @@
     &:hover {
       opacity: 1;
     }
+  }
+}
+
+// The options list scrolls on its own so that a poll with a dozen answers stays
+// the same size as a poll with two. `.poll-options-frame` is the sized box; the
+// hints are laid over its edges, outside the scroller, so they stay put.
+.poll-options-frame {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  // Roughly four options before scrolling kicks in. `min-height` keeps a couple
+  // of options readable when the 40% cap on the frame squeezes this further.
+  min-height: 4.5em;
+  max-height: 15em;
+}
+
+.poll-options-scroller {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+
+.poll-options {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+
+  .opt:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.poll-options-more {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2.4em;
+  display: none;
+  font-size: 0.75em;
+  line-height: 1.6em;
+  font-weight: 500;
+  color: a.$text-color1;
+  text-align: center;
+  // Purely an affordance -- clicks belong to the option underneath.
+  pointer-events: none;
+  user-select: none;
+
+  &::before {
+    content: '';
+    display: inline-block;
+    width: 0;
+    height: 0;
+    margin-right: 0.4em;
+    vertical-align: middle;
+    border-left: 0.3em solid transparent;
+    border-right: 0.3em solid transparent;
+  }
+}
+
+.poll-options-more-up {
+  top: 0;
+  background: linear-gradient(
+    to bottom,
+    $poll-background 0%,
+    color.change($poll-background, $alpha: 0.85) 55%,
+    color.change($poll-background, $alpha: 0) 100%
+  );
+
+  &::before {
+    border-bottom: 0.35em solid currentColor;
+  }
+}
+
+.poll-options-more-down {
+  bottom: 0;
+  // The label sits at the bottom of the box, so the fade runs the other way.
+  padding-top: 0.8em;
+  background: linear-gradient(
+    to top,
+    $poll-background 0%,
+    color.change($poll-background, $alpha: 0.85) 55%,
+    color.change($poll-background, $alpha: 0) 100%
+  );
+
+  &::before {
+    border-top: 0.35em solid currentColor;
   }
 }
 

--- a/assets/chat/js/mock-scenarios.js
+++ b/assets/chat/js/mock-scenarios.js
@@ -160,6 +160,23 @@ const POLL_QUESTIONS = [
     question: 'Is this take based?',
     options: ['Yes', 'No', 'Depends'],
   },
+  {
+    question: 'Which month is the best month?',
+    options: [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ],
+  },
 ];
 
 function pick(arr) {

--- a/assets/chat/js/poll.js
+++ b/assets/chat/js/poll.js
@@ -271,6 +271,28 @@ class ChatPoll {
     this.ui.moreBelow.toggle(below);
   }
 
+  /**
+   * Scroll the options list so `option` sits in the middle of it. Used for the
+   * winner, which is easily out of sight in a long poll: centring it keeps it
+   * away from the edges, where a scroll hint would cover it. Scrolls the list
+   * itself rather than going through scrollIntoView, which would also scroll
+   * whatever the chat is embedded in.
+   * @param {HTMLElement|undefined} option
+   */
+  centerOnOption(option) {
+    const viewport = this.ui.options.get(0);
+    if (!viewport || !option) {
+      return;
+    }
+
+    const viewportRect = viewport.getBoundingClientRect();
+    const optionRect = option.getBoundingClientRect();
+    viewport.scrollTop +=
+      optionRect.top -
+      viewportRect.top -
+      (viewportRect.height - optionRect.height) / 2;
+  }
+
   endPoll() {
     this.voting = false;
     clearTimeout(this.timerHidePoll);
@@ -295,8 +317,7 @@ class ChatPoll {
 
     const winner = this.ui.options.children().eq(winnerIndex);
     winner.addClass('opt-winner');
-    // The winner may well be scrolled out of sight in a long poll.
-    winner.get(0)?.scrollIntoView({ block: 'nearest' });
+    this.centerOnOption(winner.get(0));
     this.updateOptionOverflow();
 
     this.pollEndMessage(winnerIndex + 1, winner.data('percentage'));

--- a/assets/chat/js/poll.js
+++ b/assets/chat/js/poll.js
@@ -3,6 +3,7 @@ import { throttle } from 'throttle-debounce';
 import UserFeatures from './features';
 import UserRoles from './roles';
 import { MessageBuilder } from './messages';
+import ChatScrollPlugin from './scroll';
 import encodeUrl from './encodeUrl';
 
 const POLL_CONJUNCTION = /\bor\b/i;
@@ -77,6 +78,29 @@ function buildPollOptionHtml(option, index) {
       `;
 }
 
+/**
+ * How many of `optionRects` are cut off by the top and bottom edges of
+ * `viewportRect`. An option that is only half visible counts as hidden in that
+ * direction -- the reader still has to scroll to finish reading it.
+ * @param {{top: number, bottom: number}} viewportRect
+ * @param {Array<{top: number, bottom: number}>} optionRects
+ * @return {{above: number, below: number}}
+ */
+function countClippedOptions(viewportRect, optionRects) {
+  let above = 0;
+  let below = 0;
+  optionRects.forEach((rect) => {
+    // A pixel of slack, since subpixel layout leaves flush edges just over.
+    if (rect.top < viewportRect.top - 1) {
+      above += 1;
+    }
+    if (rect.bottom > viewportRect.bottom + 1) {
+      below += 1;
+    }
+  });
+  return { above, below };
+}
+
 class ChatPoll {
   constructor(chat) {
     this.chat = chat;
@@ -85,6 +109,8 @@ class ChatPoll {
     this.ui.votes = this.ui.find('.poll-votes');
     this.ui.question = this.ui.find('.poll-question');
     this.ui.options = this.ui.find('.poll-options');
+    this.ui.moreAbove = this.ui.find('.poll-options-more-up');
+    this.ui.moreBelow = this.ui.find('.poll-options-more-down');
     this.ui.timer = this.ui.find('.poll-timer-inner');
     this.ui.endmsg = this.ui.find('.poll-end');
     this.poll = null;
@@ -106,6 +132,26 @@ class ChatPoll {
     this.throttleVoteCast = throttle(100, () => {
       this.updateBars();
     });
+
+    // The options list is capped in height, so it gets the same overlay
+    // scrollbar the menus use, plus hints marking what is cut off. Layouts
+    // without a poll frame (the vote-only GUI) have nothing to set up.
+    const optionsViewport = this.ui.options.get(0);
+    if (optionsViewport) {
+      this.scrollplugin = new ChatScrollPlugin(
+        optionsViewport,
+        this.ui.find('.poll-options-scroller').get(0),
+      );
+      this.throttleOptionOverflow = throttle(50, () =>
+        this.updateOptionOverflow(),
+      );
+      this.ui.options.on('scroll', () => this.throttleOptionOverflow());
+      // Resizing the chat window changes how many options fit.
+      this.optionsResizeObserver = new ResizeObserver(() =>
+        this.updateOptionOverflow(),
+      );
+      this.optionsResizeObserver.observe(optionsViewport);
+    }
   }
 
   hide() {
@@ -121,6 +167,8 @@ class ChatPoll {
       this.hidden = false;
       this.ui.addClass('active');
       this.chat.mainwindow.update();
+      // Nothing inside the frame could be measured while it was hidden.
+      this.scrollplugin?.reset();
     }
   }
 
@@ -194,6 +242,10 @@ class ChatPoll {
     }
 
     this.show();
+    // Only once the frame is back on screen: while it is hidden the scroller
+    // has no layout, and showing it restores the offset the last poll left.
+    this.ui.options.scrollTop(0);
+    this.updateOptionOverflow();
   }
 
   reset() {
@@ -204,15 +256,47 @@ class ChatPoll {
     this.ui.timer.parent().show();
   }
 
+  /**
+   * Label the hints with how many options are cut off above and below the
+   * scroller, so it is obvious there is more of the poll to scroll to.
+   */
+  updateOptionOverflow() {
+    const viewport = this.ui.options.get(0);
+    if (!viewport) {
+      return;
+    }
+
+    const { above, below } = countClippedOptions(
+      viewport.getBoundingClientRect(),
+      this.ui.options
+        .children('.opt')
+        .map((_, opt) => opt.getBoundingClientRect())
+        .get(),
+    );
+
+    ChatPoll.labelOverflowHint(this.ui.moreAbove, above);
+    ChatPoll.labelOverflowHint(this.ui.moreBelow, below);
+  }
+
+  static labelOverflowHint(hint, count) {
+    if (count > 0) {
+      hint.text(`${count} more`).show();
+    } else {
+      hint.hide();
+    }
+  }
+
   endPoll() {
     this.voting = false;
     clearTimeout(this.timerHidePoll);
-    this.markWinner();
+    // Swap the timer for the end message first: markWinner() scrolls and
+    // measures the options, and both change with the height of the footer.
     this.ui.timer.parent().hide();
     this.ui.endmsg
       .text(`Poll ended! ${this.poll.votesCast} votes cast.`)
       .show();
     this.ui.addClass('poll-completed');
+    this.markWinner();
     this.timerHidePoll = setTimeout(() => this.hide(), POLL_END_TIME);
   }
 
@@ -224,12 +308,13 @@ class ChatPoll {
       0,
     );
 
-    this.ui.options.children().eq(winnerIndex).addClass('opt-winner');
+    const winner = this.ui.options.children().eq(winnerIndex);
+    winner.addClass('opt-winner');
+    // The winner may well be scrolled out of sight in a long poll.
+    winner.get(0)?.scrollIntoView({ block: 'nearest' });
+    this.updateOptionOverflow();
 
-    this.pollEndMessage(
-      winnerIndex + 1,
-      this.ui.options.children().eq(winnerIndex).data('percentage'),
-    );
+    this.pollEndMessage(winnerIndex + 1, winner.data('percentage'));
   }
 
   markVote(opt) {
@@ -303,4 +388,9 @@ class ChatPoll {
   }
 }
 
-export { ChatPoll, parseQuestionAndTime, buildPollOptionHtml };
+export {
+  ChatPoll,
+  parseQuestionAndTime,
+  buildPollOptionHtml,
+  countClippedOptions,
+};

--- a/assets/chat/js/poll.js
+++ b/assets/chat/js/poll.js
@@ -79,26 +79,19 @@ function buildPollOptionHtml(option, index) {
 }
 
 /**
- * How many of `optionRects` are cut off by the top and bottom edges of
- * `viewportRect`. An option that is only half visible counts as hidden in that
+ * Whether any of `optionRects` is cut off by the top or the bottom edge of
+ * `viewportRect`. An option that is only half visible counts as cut off in that
  * direction -- the reader still has to scroll to finish reading it.
  * @param {{top: number, bottom: number}} viewportRect
  * @param {Array<{top: number, bottom: number}>} optionRects
- * @return {{above: number, below: number}}
+ * @return {{above: boolean, below: boolean}}
  */
-function countClippedOptions(viewportRect, optionRects) {
-  let above = 0;
-  let below = 0;
-  optionRects.forEach((rect) => {
-    // A pixel of slack, since subpixel layout leaves flush edges just over.
-    if (rect.top < viewportRect.top - 1) {
-      above += 1;
-    }
-    if (rect.bottom > viewportRect.bottom + 1) {
-      below += 1;
-    }
-  });
-  return { above, below };
+function hasClippedOptions(viewportRect, optionRects) {
+  // A pixel of slack, since subpixel layout leaves flush edges just over.
+  return {
+    above: optionRects.some((rect) => rect.top < viewportRect.top - 1),
+    below: optionRects.some((rect) => rect.bottom > viewportRect.bottom + 1),
+  };
 }
 
 class ChatPoll {
@@ -257,8 +250,8 @@ class ChatPoll {
   }
 
   /**
-   * Label the hints with how many options are cut off above and below the
-   * scroller, so it is obvious there is more of the poll to scroll to.
+   * Show a hint over whichever edge of the scroller is cutting options off, so
+   * it is obvious there is more of the poll to scroll to.
    */
   updateOptionOverflow() {
     const viewport = this.ui.options.get(0);
@@ -266,7 +259,7 @@ class ChatPoll {
       return;
     }
 
-    const { above, below } = countClippedOptions(
+    const { above, below } = hasClippedOptions(
       viewport.getBoundingClientRect(),
       this.ui.options
         .children('.opt')
@@ -274,16 +267,8 @@ class ChatPoll {
         .get(),
     );
 
-    ChatPoll.labelOverflowHint(this.ui.moreAbove, above);
-    ChatPoll.labelOverflowHint(this.ui.moreBelow, below);
-  }
-
-  static labelOverflowHint(hint, count) {
-    if (count > 0) {
-      hint.text(`${count} more`).show();
-    } else {
-      hint.hide();
-    }
+    this.ui.moreAbove.toggle(above);
+    this.ui.moreBelow.toggle(below);
   }
 
   endPoll() {
@@ -392,5 +377,5 @@ export {
   ChatPoll,
   parseQuestionAndTime,
   buildPollOptionHtml,
-  countClippedOptions,
+  hasClippedOptions,
 };

--- a/assets/chat/js/poll.test.js
+++ b/assets/chat/js/poll.test.js
@@ -1,4 +1,4 @@
-import { buildPollOptionHtml } from './poll';
+import { buildPollOptionHtml, countClippedOptions } from './poll';
 
 /**
  * Parse an option's rendered HTML into a detached DOM node so we can inspect
@@ -50,5 +50,74 @@ describe('Escaping poll options (XSS prevention)', () => {
       'Café',
     );
     expect(opt.querySelector('.opt-vote-number').textContent.trim()).toBe('3');
+  });
+});
+
+/**
+ * Build the rects for `count` options of a fixed height stacked from the top of
+ * the scrolled content, as seen from a viewport scrolled down by `scrollTop`.
+ * @param {number} count
+ * @param {number} scrollTop
+ * @param {number} optionHeight
+ * @return {Array<{top: number, bottom: number}>}
+ */
+function optionRects(count, scrollTop, optionHeight = 40) {
+  return Array.from({ length: count }, (_, i) => ({
+    top: i * optionHeight - scrollTop,
+    bottom: (i + 1) * optionHeight - scrollTop,
+  }));
+}
+
+describe('Counting the poll options cut off by the scroller', () => {
+  // A viewport showing exactly three 40px options.
+  const viewport = { top: 0, bottom: 120 };
+
+  test('reports nothing hidden when every option fits', () => {
+    expect(countClippedOptions(viewport, optionRects(3, 0))).toEqual({
+      above: 0,
+      below: 0,
+    });
+  });
+
+  test('counts the options below when scrolled to the top', () => {
+    expect(countClippedOptions(viewport, optionRects(12, 0))).toEqual({
+      above: 0,
+      below: 9,
+    });
+  });
+
+  test('counts the options above when scrolled to the bottom', () => {
+    expect(countClippedOptions(viewport, optionRects(12, 360))).toEqual({
+      above: 9,
+      below: 0,
+    });
+  });
+
+  test('counts in both directions when scrolled to the middle', () => {
+    expect(countClippedOptions(viewport, optionRects(12, 160))).toEqual({
+      above: 4,
+      below: 5,
+    });
+  });
+
+  test('counts a partly visible option as hidden, since it still needs scrolling to', () => {
+    // Scrolled by half an option, so the first and last are each half cut off.
+    expect(countClippedOptions(viewport, optionRects(4, 20))).toEqual({
+      above: 1,
+      below: 1,
+    });
+  });
+
+  test('tolerates a subpixel overhang at a flush edge', () => {
+    const flush = [
+      { top: -0.4, bottom: 39.6 },
+      { top: 39.6, bottom: 79.6 },
+      { top: 79.6, bottom: 120.4 },
+    ];
+
+    expect(countClippedOptions(viewport, flush)).toEqual({
+      above: 0,
+      below: 0,
+    });
   });
 });

--- a/assets/chat/js/poll.test.js
+++ b/assets/chat/js/poll.test.js
@@ -1,4 +1,4 @@
-import { buildPollOptionHtml, countClippedOptions } from './poll';
+import { buildPollOptionHtml, hasClippedOptions } from './poll';
 
 /**
  * Parse an option's rendered HTML into a detached DOM node so we can inspect
@@ -68,43 +68,43 @@ function optionRects(count, scrollTop, optionHeight = 40) {
   }));
 }
 
-describe('Counting the poll options cut off by the scroller', () => {
+describe('Detecting poll options cut off by the scroller', () => {
   // A viewport showing exactly three 40px options.
   const viewport = { top: 0, bottom: 120 };
 
-  test('reports nothing hidden when every option fits', () => {
-    expect(countClippedOptions(viewport, optionRects(3, 0))).toEqual({
-      above: 0,
-      below: 0,
+  test('finds nothing cut off when every option fits', () => {
+    expect(hasClippedOptions(viewport, optionRects(3, 0))).toEqual({
+      above: false,
+      below: false,
     });
   });
 
-  test('counts the options below when scrolled to the top', () => {
-    expect(countClippedOptions(viewport, optionRects(12, 0))).toEqual({
-      above: 0,
-      below: 9,
+  test('points down only when scrolled to the top', () => {
+    expect(hasClippedOptions(viewport, optionRects(12, 0))).toEqual({
+      above: false,
+      below: true,
     });
   });
 
-  test('counts the options above when scrolled to the bottom', () => {
-    expect(countClippedOptions(viewport, optionRects(12, 360))).toEqual({
-      above: 9,
-      below: 0,
+  test('points up only when scrolled to the bottom', () => {
+    expect(hasClippedOptions(viewport, optionRects(12, 360))).toEqual({
+      above: true,
+      below: false,
     });
   });
 
-  test('counts in both directions when scrolled to the middle', () => {
-    expect(countClippedOptions(viewport, optionRects(12, 160))).toEqual({
-      above: 4,
-      below: 5,
+  test('points both ways when scrolled to the middle', () => {
+    expect(hasClippedOptions(viewport, optionRects(12, 160))).toEqual({
+      above: true,
+      below: true,
     });
   });
 
-  test('counts a partly visible option as hidden, since it still needs scrolling to', () => {
+  test('counts a partly visible option as cut off, since it still needs scrolling to', () => {
     // Scrolled by half an option, so the first and last are each half cut off.
-    expect(countClippedOptions(viewport, optionRects(4, 20))).toEqual({
-      above: 1,
-      below: 1,
+    expect(hasClippedOptions(viewport, optionRects(4, 20))).toEqual({
+      above: true,
+      below: true,
     });
   });
 
@@ -115,9 +115,9 @@ describe('Counting the poll options cut off by the scroller', () => {
       { top: 79.6, bottom: 120.4 },
     ];
 
-    expect(countClippedOptions(viewport, flush)).toEqual({
-      above: 0,
-      below: 0,
+    expect(hasClippedOptions(viewport, flush)).toEqual({
+      above: false,
+      below: false,
     });
   });
 });

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -15,7 +15,13 @@
           <span class="poll-votes"></span>
         </div>
       </div>
-      <div class="poll-options"></div>
+      <div class="poll-options-frame">
+        <div class="poll-options-scroller">
+          <div class="poll-options"></div>
+        </div>
+        <div class="poll-options-more poll-options-more-up"></div>
+        <div class="poll-options-more poll-options-more-down"></div>
+      </div>
       <div class="poll-footer">
         <div class="poll-timer">
           <div class="poll-timer-inner"></div>

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -19,8 +19,12 @@
         <div class="poll-options-scroller">
           <div class="poll-options"></div>
         </div>
-        <div class="poll-options-more poll-options-more-up"></div>
-        <div class="poll-options-more poll-options-more-down"></div>
+        <div class="poll-options-more poll-options-more-up">
+          Scroll for more
+        </div>
+        <div class="poll-options-more poll-options-more-down">
+          Scroll for more
+        </div>
       </div>
       <div class="poll-footer">
         <div class="poll-timer">

--- a/jest.stylemock.js
+++ b/jest.stylemock.js
@@ -1,0 +1,3 @@
+// Stylesheets imported by modules under test carry no behaviour, and jest has
+// no loader for them, so they resolve to nothing.
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
   },
   "jest": {
     "testEnvironment": "jsdom",
+    "moduleNameMapper": {
+      "\\.(css|scss)$": "<rootDir>/jest.stylemock.js"
+    },
     "setupFilesAfterEnv": [
       "<rootDir>/jest.setup.js"
     ]


### PR DESCRIPTION
A poll with many options filled a large part of the chat window and kept it
that way for as long as the poll ran, pushing the conversation off screen.

## What changed

The options list now scrolls on its own, capped at whichever is smaller of
~4 options and 40% of the chat window, with a floor so a short window still
shows a couple. A poll with twelve answers is now the same size as a poll
with two.

It uses the same overlay scrollbar as the menus, which auto-hides, so there
is also a hint over each edge of the list: a caret and "Scroll for more",
shown only on the side that is actually cutting options off, fading out the
clipped option beneath it. The hints ignore pointer events, so clicking one
still votes for the option underneath.

Scrolling brings a few knock-on changes:

- A finished poll centres its winner in the list, which would otherwise be
  off screen as often as not. It scrolls the list directly rather than using
  `scrollIntoView`, which would also scroll whatever the chat is embedded in.
- `endPoll` swaps the timer for the end message *before* marking the winner,
  since both the scroll and the hint visibility are measured against a layout
  that the shorter footer changes.
- A new poll resets the scroll after the frame is shown, not before -- while
  it is hidden the scroller has no layout, and showing it restores the offset
  the last poll left behind.

## Also here

- `hasClippedOptions` is a pure helper with unit tests, including the
  half-visible and subpixel-slack cases.
- Jest gained a module mapping for stylesheet imports. `poll.js` now reaches
  `scroll.js`, which imports `overlayscrollbars.css`, and jest has no loader
  for CSS -- without the mapping the existing poll tests fail to import.
- The mock scenarios gained a twelve-option question, since every existing
  mock poll fits on screen and so `/mock poll` could not reach this case.

## Checked

In the chat against a real twelve-option poll: wheel scrolling, click-to-vote
through the hint overlay, resizing the chat (the hints track it), a new poll
opening at the top, and the end state centring the winner clear of both hints
-- including the clamped cases where the first or last option wins.