### PR TITLE
Add an emote suggestions display setting to the autocomplete helper

### DIFF
--- a/assets/chat/css/chat/_autocomplete.scss
+++ b/assets/chat/css/chat/_autocomplete.scss
@@ -66,6 +66,30 @@
   }
 }
 
+#chat[data-autocompleteemotedisplay='name'] .autocomplete-entry__emote {
+  display: none;
+}
+
+#chat[data-autocompleteemotedisplay='emote'] {
+  .autocomplete-entry__emote + .autocomplete-entry__name {
+    display: none;
+  }
+
+  .autocomplete-entry__emote {
+    border-radius: a.$bradius;
+  }
+
+  .autocomplete-entry:hover .autocomplete-entry__emote {
+    background: rgba(a.$color-surface-light1, 0.08);
+  }
+
+  .autocomplete-entry.active .autocomplete-entry__emote {
+    background: rgba(a.$color-surface-light1, 0.16);
+    box-shadow: 0 0 0 3px rgba(a.$color-surface-light1, 0.16);
+    filter: drop-shadow(0 0 4px a.$color-surface-light1);
+  }
+}
+
 #chat:not(.pref-autocompletehelper) #chat-auto-complete {
   display: none;
 }

--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -871,6 +871,12 @@ class Chat {
     $(document.body).toggleClass(`pref-fontscale`, fontscale !== 'auto');
     $(document.body).attr('data-fontscale', fontscale);
 
+    // Autocomplete emote display
+    this.ui.attr(
+      'data-autocompleteemotedisplay',
+      this.settings.get('autocompleteemotedisplay') || 'both',
+    );
+
     for (const window of this.windows.values()) {
       window.updateMessages(this);
     }

--- a/assets/chat/js/const.js
+++ b/assets/chat/js/const.js
@@ -134,6 +134,7 @@ const settingsdefault = new Map(
     notificationtimeout: true,
     ignorementions: false,
     autocompletehelper: true,
+    autocompleteemotedisplay: 'both', // 'both' | 'name' | 'emote'
     taggedvisibility: false,
     hidensfw: false,
     hidensfl: false,

--- a/assets/views/embed.html
+++ b/assets/views/embed.html
@@ -254,6 +254,18 @@
                 Auto-complete helper
               </label>
             </div>
+            <div class="form-group">
+              <label for="autocompleteemotedisplay">Emote suggestions</label>
+              <select
+                class="form-control"
+                id="autocompleteemotedisplay"
+                name="autocompleteemotedisplay"
+              >
+                <option value="both">Emote and name</option>
+                <option value="name">Name only</option>
+                <option value="emote">Emote only</option>
+              </select>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Emote entries in the autocomplete helper have shown both the thumbnail and the name since #839. This adds an **Emote suggestions** select under the Autocomplete heading in settings so users can hide one side:

| value | shows |
|---|---|
| `both` | thumbnail and name (default, unchanged) |
| `name` | name only, the pre-2.69 look |
| `emote` | thumbnail only |

## how

- `autocompleteemotedisplay` joins `settingsdefault` as `'both'`. No schema bump: `setSettings()` only copies keys present in the stored map, so existing users get the default.
- `applySettings()` writes the value onto `#chat` as `data-autocompleteemotedisplay`, the same way `fontscale` becomes `data-fontscale`.
- The rest is CSS in `_autocomplete.scss`. User entries carry no thumbnail, so the `__emote + __name` sibling selector never hides a username.
- In emote-only mode the name text, which is the only hover/active cue, is hidden, so the focused thumbnail gets a background pill and glow instead. The pill is box-shadow spread rather than padding so entries don't shift as TAB moves focus.

The settings menu already binds `select` changes and restores their values on open, so no menu JS changed.