### PR TITLE
Give loadSettings() a rejection handler that actually catches

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -693,7 +693,7 @@ class Chat {
         this.cacheSettings();
         this.getActiveWindow().update(true);
       })
-      .catch();
+      .catch(() => {});
   }
 
   async loadEmotesAndFlairs() {


### PR DESCRIPTION
`loadSettings()` ends its promise chain with a bare `.catch()`. With no handler that's `.then(undefined, undefined)`, which forwards the rejection instead of handling it. Nothing awaits `loadSettings()` from `onME()`, so anything thrown in the chain becomes an unhandled rejection.

In the dev server that happens on every mock-mode start: `MockChatSource` marks the user as authenticated, the `/api` proxy forwards `/api/chat/me/settings` to destiny.gg with no session, and the API answers 403 with `{"code":403,"title":"Forbidden"}`. `new Map(data)` on that object throws:

```
TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator))
    at new Map (<anonymous>)
```

webpack-dev-server's runtime-error overlay then covers the page. The chat underneath still works, so the only effect is the overlay and console noise, but it's the first thing anyone following the README's mock-mode instructions sees.

## fix

`.catch(() => {})`, the same handler `loadUnreadCount()` already uses, so the "no profile settings" case is swallowed as originally intended.

The bare `fetch(...).catch()` calls in `saveSettings()`, the message-open POST, and `ChatSettingsMenu` have the same shape, but they only reject on network failure and nothing in their chains throws, so this leaves them alone.